### PR TITLE
Fix actions, and add build artifacts for Windows-x86

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -21,6 +21,7 @@ env:
   # You can convert this to a build matrix if you need coverage of multiple configuration types.
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
   BUILD_CONFIGURATION: Debug
+  BUILD_PLATFORM: x86
 
 permissions:
   contents: read
@@ -43,4 +44,4 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -10,6 +10,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
+    branches: [ "main" ]
 
 env:
   # Path to the solution file relative to the root of the project.

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -45,3 +45,11 @@ jobs:
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Generate MSBuild archives
+      uses: actions/upload-artifact@v3
+      with:
+        name: pragma-msbuild-${{env.BUILD_PLATFORM}}
+        path: |
+            build/engine.exe
+            build/renderer_ogl1.lib

--- a/src/client/cl_pred.c
+++ b/src/client/cl_pred.c
@@ -257,10 +257,10 @@ void CL_PredictMovement (void)
 
 #ifdef PMOVE_PROGS
 	cl_globalvars_t* vars;
+	vars = cl.script_globals; // Reki (December 27 2023): Can cl.script_globals be NULL? hopefully not.
+
 	if (cl.qcvm_active && cl.entities)
 	{
-		vars = cl.script_globals;
-
 		//
 		// copy pmove state TO cgame
 		//

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -34,6 +34,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #ifdef _M_IX86
 #define	CPUSTRING	"x86"
+#elif defined(_M_X64)
+#define	CPUSTRING	"x64"
+#else
+#define	CPUSTRING	"NON-x86/x64"
 #endif
 
 #else	// !WIN32


### PR DESCRIPTION
Fixed a warning that was being treated as an error
Fixed CPUSTRING being potentially undefined in qcommon.h
Fixed action being compiled as 64-bit when engine is not set up for that yet
Added build uploads to the action workflow