### PR TITLE
Genericize button names and expose cmd button bits to CGame

### DIFF
--- a/progs_src/bg/bg_pmove.qc
+++ b/progs_src/bg/bg_pmove.qc
@@ -92,6 +92,7 @@ vector		pmove_cmd_angles;			// shorts, use SHORT2ANGLE / ANGLE2SHORT
 float		pmove_cmd_forwardmove;		// multiplied by `cl_forwardspeed` cvar
 float		pmove_cmd_sidemove;			// multiplied by `cl_sidespeed` cvar
 float		pmove_cmd_upmove;			// multiplied by `cl_upspeed` cvar
+int			pmove_cmd_buttons;			// button bitfield sent by the client
 float		pmove_snapinitial;			// if state has been changed outside pmove
 int			pmove_numtouch;				// number of entities in touch (unused clientside)
 entity		pmove_touchents[pm_maxtouch];	// array of server entities (unused clientside)
@@ -1523,7 +1524,7 @@ Client's entry point to pmove
 ================
 */
 #ifdef CLGAME
-void(vector cmdMove, vector cmdAngles, float cmdMsec) CG_PlayerMove
+void(vector cmdMove, vector cmdAngles, float cmdButtons, float cmdMsec) CG_PlayerMove
 {
 	//
 	// wipe all pmove data
@@ -1539,6 +1540,7 @@ void(vector cmdMove, vector cmdAngles, float cmdMsec) CG_PlayerMove
 	pmove_cmd_upmove = cmdMove_z;
 	pmove_cmd_msec = cmdMsec;
 	pmove_cmd_angles = cmdAngles;
+	pmove_cmd_buttons = cmdButtons;
 
 #if PMOVEDEBUGMENU == 1
 	cvarset("pmdebug_0", "movecmd: ", ftos(cmdMove_x)," FWD, ", ftos(cmdMove_y), " SIDE, ", ftos(cmdMove_z)," UP");
@@ -1578,7 +1580,7 @@ Can be called by either the server or the client
 ================
 */
 #ifdef SVGAME
-void(vector cmdMove, vector cmdAngles, int cmdMsec) SV_PlayerMove =
+void(vector cmdMove, vector cmdAngles, int cmdButtons, int cmdMsec) SV_PlayerMove =
 {
 	entity ground;
 	
@@ -1601,6 +1603,7 @@ void(vector cmdMove, vector cmdAngles, int cmdMsec) SV_PlayerMove =
 	pmove_cmd_upmove = cmdMove_z;
 	pmove_cmd_msec = cmdMsec;
 	pmove_cmd_angles = cmdAngles;
+	pmove_cmd_buttons = cmdButtons;
 	
 	pm_state_pm_type = self.pm_type;
 	pm_state_origin = self.origin;

--- a/progs_src/inc/pragma_structs_client.qc
+++ b/progs_src/inc/pragma_structs_client.qc
@@ -47,7 +47,7 @@ vector		cam_viewoffset;
 void()		CG_Main;
 void()		CG_Frame;
 void()		CG_DrawGUI;
-void(vector cmdMove, vector cmdAngles, float cmdMsec)	CG_PlayerMove;
+void(vector cmdMove, vector cmdAngles, float cmdButtons, float cmdMsec)	CG_PlayerMove;
 void(float inCommand)	CG_ServerCommand;
 	
 void end_sys_globals;

--- a/src/client/cl_pred.c
+++ b/src/client/cl_pred.c
@@ -312,7 +312,8 @@ void CL_PredictMovement (void)
 			Scr_BindVM(VM_CLGAME); // always bing qcvm here, or some weird things may happen when on loopback servers
 			Scr_AddVector(0, inmove);
 			Scr_AddVector(1, inangles);
-			Scr_AddFloat(2, (float)cmd->msec);
+			Scr_AddFloat(2, (float)cmd->buttons);
+			Scr_AddFloat(3, (float)cmd->msec);
 			Scr_Execute(VM_CLGAME, cl.script_globals->CG_PlayerMove, __FUNCTION__);
 
 			//


### PR DESCRIPTION
Removed hardcoded buttons in favor of FTE-style "`+button0`, `+button1`, `+button2` etc" commands. I did this with an X-macro to avoid copy-pasted code and to make it easier in the future to add more buttons, but feel free to change this if you don't like the implementation.

Also the hardcoded aliases are ugly, and should probably be done in a given game's `default.cfg`, since I presume the base engine should be totally clean as far as assumptions about what buttons do what.

I had to break compat with previous CGame to add the `cmdButtons` argument, since I didn't want to just tack them on the end of the function. I figured this is okay at the current stage of development.