### PR TITLE
PROTOCOL_INT_PMFLAGS protocol extension to allow int32 pm_flags

### DIFF
--- a/progs_src/bg/bg_pmove.qc
+++ b/progs_src/bg/bg_pmove.qc
@@ -44,14 +44,30 @@ typedef enum
 //
 // player movement flags
 //
-float PMF_CROUCHING			= 1;	// crouching
-float PMF_JUMP_HELD			= 2;	// holding jump
-float PMF_ON_GROUND			= 4;	// touching ground
-float PMF_TIME_WATERJUMP	= 8;	// pm_time is waterjump
-float PMF_TIME_LAND			= 16;	// pm_time is time before rejump
-float PMF_TIME_TELEPORT		= 32;	// pm_time is non-moving time
-float PMF_NO_PREDICTION		= 64;	// temporarily disables prediction -- !!! THIS MUST MATCH C CODE !!!
-float PMF_FREE				= 128;	// the only free for use pmflag, can't have more without changing pm_flags to short in C network code
+float PMF_CROUCHING			= (1 << 0);	// crouching
+float PMF_JUMP_HELD			= (1 << 1);	// holding jump
+float PMF_ON_GROUND			= (1 << 2);	// touching ground
+float PMF_TIME_WATERJUMP	= (1 << 3);	// pm_time is waterjump
+float PMF_TIME_LAND			= (1 << 4);	// pm_time is time before rejump
+float PMF_TIME_TELEPORT		= (1 << 5);	// pm_time is non-moving time
+float PMF_NO_PREDICTION		= (1 << 6);	// temporarily disables prediction -- !!! THIS MUST MATCH C CODE !!!
+float PMF_FLAG7				= (1 << 7);	// unused
+float PMF_FLAG8				= (1 << 8);	// unused
+float PMF_FLAG9				= (1 << 9);	// unused
+float PMF_FLAG10			= (1 << 10);	// unused
+float PMF_FLAG11			= (1 << 11);	// unused
+float PMF_FLAG12			= (1 << 12);	// unused
+float PMF_FLAG13			= (1 << 13);	// unused
+float PMF_FLAG14			= (1 << 14);	// unused
+float PMF_FLAG15			= (1 << 15);	// unused
+float PMF_FLAG16			= (1 << 16);	// unused
+float PMF_FLAG17			= (1 << 17);	// unused
+float PMF_FLAG18			= (1 << 18);	// unused
+float PMF_FLAG19			= (1 << 19);	// unused
+float PMF_FLAG20			= (1 << 20);	// unused
+float PMF_FLAG21			= (1 << 21);	// unused
+float PMF_FLAG22			= (1 << 22);	// unused
+float PMF_FLAG23			= (1 << 23);	// unused
 // ---------------------------------------------------
 //
 // movement parameters

--- a/src/client/cl_ents.c
+++ b/src/client/cl_ents.c
@@ -415,7 +415,7 @@ void CL_ParsePlayerstate(frame_t *oldframe, frame_t *newframe)
 
 	flags = MSG_ReadShort (&net_message);
 	if (flags & PS_EXTRABYTES)
-		flags = (MSG_ReadShort (&net_message) << 16) | (flags & 0xFFFF); // Reki: Allow extra bytes, so we don't choke ourselves
+		flags = (MSG_ReadShort (&net_message) << 16) | (flags & 0xFFFF); // reki --  Allow extra bytes, so we don't choke ourselves
 
 	//
 	// parse the pmove_state_t

--- a/src/client/cl_ents.c
+++ b/src/client/cl_ents.c
@@ -414,6 +414,8 @@ void CL_ParsePlayerstate(frame_t *oldframe, frame_t *newframe)
 		memset (state, 0, sizeof(*state));
 
 	flags = MSG_ReadShort (&net_message);
+	if (flags & PS_EXTRABYTES)
+		flags = (MSG_ReadShort (&net_message) << 16) | (flags & 0xFFFF); // Reki: Allow extra bytes, so we don't choke ourselves
 
 	//
 	// parse the pmove_state_t
@@ -449,7 +451,9 @@ void CL_ParsePlayerstate(frame_t *oldframe, frame_t *newframe)
 	if (flags & PS_M_FLAGS)
 	{
 #if PROTOCOL_INT_PMFLAGS == 1
-		state->pmove.pm_flags = MSG_ReadLong (&net_message);
+		state->pmove.pm_flags = MSG_ReadShort (&net_message);
+		if (flags & PS_M_FLAGSLONG)
+			state->pmove.pm_flags = (MSG_ReadShort (&net_message) << 16) | (state->pmove.pm_flags & 0xFFFF);
 #else
 		state->pmove.pm_flags = MSG_ReadByte (&net_message);
 #endif

--- a/src/client/cl_ents.c
+++ b/src/client/cl_ents.c
@@ -450,13 +450,9 @@ void CL_ParsePlayerstate(frame_t *oldframe, frame_t *newframe)
 
 	if (flags & PS_M_FLAGS)
 	{
-#if PROTOCOL_INT_PMFLAGS == 1
 		state->pmove.pm_flags = MSG_ReadShort (&net_message);
 		if (flags & PS_M_FLAGSLONG)
 			state->pmove.pm_flags = (MSG_ReadShort (&net_message) << 16) | (state->pmove.pm_flags & 0xFFFF);
-#else
-		state->pmove.pm_flags = MSG_ReadByte (&net_message);
-#endif
 	}
 
 	if (flags & PS_M_GRAVITY)

--- a/src/client/cl_ents.c
+++ b/src/client/cl_ents.c
@@ -447,7 +447,13 @@ void CL_ParsePlayerstate(frame_t *oldframe, frame_t *newframe)
 		state->pmove.pm_time = MSG_ReadByte (&net_message);
 
 	if (flags & PS_M_FLAGS)
+	{
+#if PROTOCOL_INT_PMFLAGS == 1
+		state->pmove.pm_flags = MSG_ReadLong (&net_message);
+#else
 		state->pmove.pm_flags = MSG_ReadByte (&net_message);
+#endif
+	}
 
 	if (flags & PS_M_GRAVITY)
 		state->pmove.gravity = MSG_ReadShort (&net_message);

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -53,7 +53,7 @@ Key_Event (int key, qboolean down, unsigned time);
 ===============================================================================
 */
 
-// Reki (December 28 2023): Changed buttons to be generic, since we don't know how gamecode will want to use them
+// reki -- 28-12-23 Changed buttons to be generic, since we don't know how gamecode will want to use them
 // If you don't like X-Macros, feel free to swap it out to just a list of defs, I like using them in cases like this.
 #define LIST_BUTTONS \
 	X(0) \
@@ -457,7 +457,7 @@ void CL_InitInput (void)
 	Cmd_AddCommand ("-button" #bit, IN_Button##bit##Up);
 	LIST_BUTTONS
 	#undef X
-	// Reki (December 28 2023): Still have to add aliases for the old commands, this should probably be in the config file instead.
+	// reki -- 28-12-23 Still have to add aliases for the old commands, this should probably be in the config file instead.
 	Cbuf_AddText ("alias +attack +button0\nalias -attack -button0\n");
 	Cbuf_AddText ("alias +use +button1\nalias -use -button1\n");
 	Cbuf_AddText ("alias +reload +button2\nalias -reload -button2\n");

--- a/src/client/cl_pred.c
+++ b/src/client/cl_pred.c
@@ -258,7 +258,7 @@ void CL_PredictMovement (void)
 
 	if (cl.qcvm_active && cl.entities)
 	{
-		cgGlobals = cl.script_globals;	// Reki (December 27 2023): Can cl.script_globals be NULL? hopefully not. 
+		cgGlobals = cl.script_globals;	// reki -- 27-12-23 Can cl.script_globals be NULL? hopefully not. 
 										// BraXi - yup, can be when !cl.qcvm_active
 
 		//

--- a/src/pragma_config.h
+++ b/src/pragma_config.h
@@ -13,9 +13,6 @@
 // all entities can move beyond +/- 4096qu boundary, 
 #define PROTOCOL_FLOAT_COORDS 1
 
-// pmove will use int for pmflags
-#define PROTOCOL_INT_PMFLAGS 1
-
 // player view angles will use floats instead shorts
 #define PROTOCOL_FLOAT_PLAYERANGLES 0
 

--- a/src/pragma_config.h
+++ b/src/pragma_config.h
@@ -13,6 +13,9 @@
 // all entities can move beyond +/- 4096qu boundary, 
 #define PROTOCOL_FLOAT_COORDS 1
 
+// pmove will use int for pmflags
+#define PROTOCOL_INT_PMFLAGS 1
+
 // player view angles will use floats instead shorts
 #define PROTOCOL_FLOAT_PLAYERANGLES 0
 

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -535,7 +535,11 @@ typedef struct
 	short		maxs[3];	// 12.3
 #endif
 
+#if PROTOCOL_INT_PMFLAGS == 1
+	int			pm_flags; 		// ducked, jump_held, etc
+#else
 	byte		pm_flags;		// ducked, jump_held, etc
+#endif
 	byte		pm_time;		// each unit = 8 ms
 	short		gravity;
 

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -504,13 +504,13 @@ typedef enum
 } pmtype_t;
 
 // pmove->pm_flags
-#define	PMF_DUCKED			1
-#define	PMF_JUMP_HELD		2
-#define	PMF_ON_GROUND		4
-#define	PMF_TIME_WATERJUMP	8	// pm_time is waterjump
-#define	PMF_TIME_LAND		16	// pm_time is time before rejump
-#define	PMF_TIME_TELEPORT	32	// pm_time is non-moving time
-#define PMF_NO_PREDICTION	64	// temporarily disables prediction (used for grappling hook)
+#define	PMF_DUCKED			(1 << 0)
+#define	PMF_JUMP_HELD		(1 << 1)
+#define	PMF_ON_GROUND		(1 << 2)
+#define	PMF_TIME_WATERJUMP	(1 << 3)	// pm_time is waterjump
+#define	PMF_TIME_LAND		(1 << 4)	// pm_time is time before rejump
+#define	PMF_TIME_TELEPORT	(1 << 5)	// pm_time is non-moving time
+#define PMF_NO_PREDICTION	(1 << 6)	// temporarily disables prediction (used for grappling hook)
 
 // this structure needs to be communicated bit-accurate
 // from the server to the client to guarantee that
@@ -535,11 +535,7 @@ typedef struct
 	short		maxs[3];	// 12.3
 #endif
 
-#if PROTOCOL_INT_PMFLAGS == 1
 	int			pm_flags; 		// ducked, jump_held, etc
-#else
-	byte		pm_flags;		// ducked, jump_held, etc
-#endif
 	byte		pm_time;		// each unit = 8 ms
 	short		gravity;
 

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -313,7 +313,6 @@ enum clc_ops_e
 #define	PS_M_FLAGS			(1<<4)
 #define	PS_M_GRAVITY		(1<<5)
 #define	PS_M_DELTA_ANGLES	(1<<6)
-#define	PS_M_BBOX_SIZE		(1<<15) // braxi -- added bbox size, maybe make it byte?
 
 #define	PS_VIEWOFFSET		(1<<7)
 #define	PS_VIEWANGLES		(1<<8)
@@ -323,6 +322,10 @@ enum clc_ops_e
 #define	PS_VIEWMODEL_INDEX	(1<<12)
 #define	PS_VIEWMODEL_FRAME	(1<<13)
 #define	PS_RDFLAGS			(1<<14)
+
+#define PS_EXTRABYTES		(1<<15) // Reki (December 28 2023): added this so we don't shoot ourselves in the foot later, looking for more bytes
+#define	PS_M_BBOX_SIZE		(1<<16) // braxi -- added bbox size, maybe make it byte?
+#define PS_M_FLAGSLONG		(1<<17) // Reki (December 28 2023): if our mod is using a lot of pmove flags, make sure they're networked
 
 
 //==============================================

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -323,9 +323,9 @@ enum clc_ops_e
 #define	PS_VIEWMODEL_FRAME	(1<<13)
 #define	PS_RDFLAGS			(1<<14)
 
-#define PS_EXTRABYTES		(1<<15) // Reki (December 28 2023): added this so we don't shoot ourselves in the foot later, looking for more bytes
+#define PS_EXTRABYTES		(1<<15) // reki -- 28-12-23 added this so we don't shoot ourselves in the foot later, looking for more bytes
 #define	PS_M_BBOX_SIZE		(1<<16) // braxi -- added bbox size, maybe make it byte?
-#define PS_M_FLAGSLONG		(1<<17) // Reki (December 28 2023): if our mod is using a lot of pmove flags, make sure they're networked
+#define PS_M_FLAGSLONG		(1<<17) // reki -- 28-12-23 if our mod is using a lot of pmove flags, make sure they're networked
 
 
 //==============================================

--- a/src/server/sv_write.c
+++ b/src/server/sv_write.c
@@ -166,10 +166,8 @@ void SV_WritePlayerstateToClient (client_frame_t *from, client_frame_t *to, size
 	if (ps->pmove.pm_flags != ops->pmove.pm_flags)
 	{
 		pflags |= PS_M_FLAGS;
-#if PROTOCOL_INT_PMFLAGS == 1
 		if ((ps->pmove.pm_flags ^ ops->pmove.pm_flags) & 0xFFFF0000) // reki --  if we have any big bits delta'd, we need to send them
 			pflags |= PS_M_FLAGSLONG;
-#endif
 	}
 
 	if (ps->pmove.gravity != ops->pmove.gravity)
@@ -264,13 +262,9 @@ void SV_WritePlayerstateToClient (client_frame_t *from, client_frame_t *to, size
 
 	if (pflags & PS_M_FLAGS)
 	{
-#if PROTOCOL_INT_PMFLAGS == 1
 		MSG_WriteShort (msg, ps->pmove.pm_flags);
 		if (pflags & PS_M_FLAGSLONG)
 			MSG_WriteShort (msg, (ps->pmove.pm_flags >> 16));
-#else
-		MSG_WriteByte (msg, ps->pmove.pm_flags);
-#endif
 	}
 
 	if (pflags & PS_M_GRAVITY)

--- a/src/server/sv_write.c
+++ b/src/server/sv_write.c
@@ -167,7 +167,7 @@ void SV_WritePlayerstateToClient (client_frame_t *from, client_frame_t *to, size
 	{
 		pflags |= PS_M_FLAGS;
 #if PROTOCOL_INT_PMFLAGS == 1
-		if ((ps->pmove.pm_flags ^ ops->pmove.pm_flags) & 0xFFFF0000) // Reki: if we have any big bits delta'd, we need to send them
+		if ((ps->pmove.pm_flags ^ ops->pmove.pm_flags) & 0xFFFF0000) // reki --  if we have any big bits delta'd, we need to send them
 			pflags |= PS_M_FLAGSLONG;
 #endif
 	}
@@ -229,7 +229,7 @@ void SV_WritePlayerstateToClient (client_frame_t *from, client_frame_t *to, size
 	//
 	MSG_WriteByte (msg, SVC_PLAYERINFO);
 	MSG_WriteShort (msg, pflags);
-	if (pflags & PS_EXTRABYTES) // Reki: Send the extra bytes
+	if (pflags & PS_EXTRABYTES) // reki --  Send the extra bytes
 		MSG_WriteShort(msg, (pflags >> 16));
 	//
 	// write the pmove_state_t

--- a/src/server/sv_write.c
+++ b/src/server/sv_write.c
@@ -253,7 +253,13 @@ void SV_WritePlayerstateToClient (client_frame_t *from, client_frame_t *to, size
 		MSG_WriteByte (msg, ps->pmove.pm_time);
 
 	if (pflags & PS_M_FLAGS)
+	{
+#if PROTOCOL_INT_PMFLAGS == 1
+		MSG_WriteLong (msg, ps->pmove.pm_flags);
+#else
 		MSG_WriteByte (msg, ps->pmove.pm_flags);
+#endif
+	}
 
 	if (pflags & PS_M_GRAVITY)
 		MSG_WriteShort (msg, ps->pmove.gravity);


### PR DESCRIPTION
Added PROTOCOL_INT_PMFLAGS config, to enable extended `pm_flags`.

Refactored playerstate networking to allow for 32 possible delta flags, instead of 16. In the process of doing this I had to move `PS_M_BBOX_SIZE` up 1 bit so we could signal to the client that there is more to read. `PS_M_FLAGSLONG` signifies that there is `pm_flags` above `0xFFFF` that need networking.

QuakeC can only use 24 `pm_flags` currently, because they are stored as floats, I didn't want to start poking at that because of previously discussed FTEQCC int weirdness.

Also restyled comments.