### PR TITLE
Remove usage of fixed function matricies for models and the world and…

### DIFF
--- a/src/qcommon/mathlib.h
+++ b/src/qcommon/mathlib.h
@@ -15,7 +15,9 @@ typedef vec_t rect_t[4];
 typedef vec_t rgba_t[4];
 
 typedef vec_t mat3x3_t[3][3];
-//typedef vec_t mat4x4_t[4][4]; // unused
+//Column-major matrix, intended for OpenGL. 
+typedef vec_t mat4_t[16];
+extern mat4_t mat4_identity;
 
 typedef	int	fixed4_t;
 typedef	int	fixed8_t;
@@ -123,6 +125,20 @@ void AngleVectors(vec3_t angles, vec3_t forward, vec3_t right, vec3_t up);
 int BoxOnPlaneSide(vec3_t emins, vec3_t emaxs, struct cplane_s* plane);
 float anglemod(float a);
 float LerpAngle(float a1, float a2, float frac);
+
+void Mat4MakeIdentity(mat4_t mat);
+void Mat4Perspective(mat4_t mat, float l, float r, float b, float t, float znear, float zfar);
+//Does left x right, results in left. 
+void Mat4Multiply(mat4_t left, mat4_t right);
+//Rotates are performed by multiplying a resultant matrix against mat.
+//All rotates in the rendering code are rotations around cardinal axes, so only these are supported ATM.
+void Mat4RotateAroundX(mat4_t mat, float angle);
+void Mat4RotateAroundY(mat4_t mat, float angle);
+void Mat4RotateAroundZ(mat4_t mat, float angle);
+//Multiplies mat by a translation matrix composed of xyz.
+void Mat4Translate(mat4_t mat, float x, float y, float z);
+//Multiplies mat by a scale matrix composed of xyz.
+void Mat4Scale(mat4_t mat, float x, float y, float z);
 
 #define BOX_ON_PLANE_SIDE(emins, emaxs, p)	\
 	(((p)->type < 3)?						\

--- a/src/renderer_gl2/r_init.c
+++ b/src/renderer_gl2/r_init.c
@@ -329,6 +329,7 @@ int R_Init(void* hinstance, void* hWnd)
 		sinTable[i] = sin(DEG2RAD(i * 360.0f / ((float)(FUNCTABLE_SIZE - 1))));
 
 	R_InitModels();
+	R_InitSprites();
 	R_LoadFonts();
 
 	vb_particles = R_AllocVertexBuffer((V_UV | V_COLOR | V_NOFREE), (3 * MAX_PARTICLES), 0);

--- a/src/renderer_gl2/r_light.c
+++ b/src/renderer_gl2/r_light.c
@@ -350,28 +350,6 @@ void R_LightPoint(vec3_t p, vec3_t color)
 	else
 		VectorCopy (pointcolor, color);
 
-	//
-	// add dynamic lights
-	//
-	if (r_dynamic->value)
-	{
-		light = 0;
-		dl = r_newrefdef.dlights;
-		for (lnum = 0; lnum < r_newrefdef.num_dlights; lnum++, dl++)
-		{
-			if (dl->type == DL_SPOTLIGHT)
-				continue; // FIXME,
-
-			VectorSubtract(pCurrentRefEnt->origin, dl->origin, dist); // distance
-			add = dl->intensity - VectorLength(dist);
-			add *= (1.0 / 256);
-			if (add > 0)
-			{
-				VectorMA(color, add, dl->color, color);
-			}
-		}
-	}
-
 	// scale the light color with r_modulate cvar
 	VectorScale (color, r_modulate->value, color);
 }

--- a/src/renderer_gl2/r_local.h
+++ b/src/renderer_gl2/r_local.h
@@ -140,6 +140,10 @@ typedef enum
 	LOC_DLIGHT_POS_AND_RAD,
 	LOC_DLIGHT_DIR_AND_CUTOFF,
 
+	LOC_PROJECTION,
+	LOC_MODELVIEW,
+	LOC_LOCALMODELVIEW, //Used to properly light models
+
 	NUM_LOCS,
 } glprogLoc_t;
 
@@ -191,6 +195,7 @@ void R_ProgUniform4f(int uniform, float val, float val2, float val3, float val4)
 void R_ProgUniformVec4(int uniform, vec4_t v);
 void R_ProgUniform3fv(int uniform, int count, float* val);
 void R_ProgUniform4fv(int uniform, int count, float* val);
+void R_ProgUniformMatrix4fv(int uniform, int count, float* val);
 int R_GetProgAttribLoc(glprogLoc_t attrib);
 char* R_GetProgAttribName(glprogLoc_t attrib);
 char* R_GetCurrentProgramName();
@@ -313,7 +318,9 @@ extern	cvar_t	*r_intensity;
 extern	int		gl_tex_solid_format;
 extern	int		gl_tex_alpha_format;
 
-extern float r_world_matrix[16];
+extern mat4_t r_world_matrix;
+extern mat4_t r_local_matrix; //Transforms a vertex into its final position in the world
+extern mat4_t r_projection_matrix;
 
 
 //===================================================================
@@ -321,6 +328,7 @@ extern float r_world_matrix[16];
 //===================================================================
 extern model_t *r_worldmodel;
 extern int registration_sequence;
+void R_InitSprites();
 
 //===================================================================
 // r_init.c

--- a/src/renderer_gl2/r_md3.c
+++ b/src/renderer_gl2/r_md3.c
@@ -566,6 +566,7 @@ void DrawVertexBuffer(rentity_t *ent, vertexbuffer_t* vbo, unsigned int startVer
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
+extern qboolean r_pendingflip;
 /*
 =================
 R_DrawMD3Model
@@ -600,6 +601,11 @@ void R_DrawMD3Model(rentity_t* ent, lod_t lod, float animlerp)
 	R_ProgUniformVec3(LOC_SHADECOLOR, model_shadelight);
 	R_ProgUniformVec3(LOC_SHADEVECTOR, model_shadevector);
 	R_ProgUniform1f(LOC_LERPFRAC, animlerp);
+	R_ProgUniformMatrix4fv(LOC_LOCALMODELVIEW, 1, r_local_matrix);
+	if (r_pendingflip)
+	{
+		R_ProgUniformMatrix4fv(LOC_PROJECTION, 1, r_projection_matrix);
+	}
 
 	if (r_fullbright->value || pCurrentRefEnt->renderfx & RF_FULLBRIGHT)
 		R_ProgUniform1f(LOC_PARM0, 1);
@@ -633,6 +639,12 @@ void R_DrawMD3Model(rentity_t* ent, lod_t lod, float animlerp)
 		DrawVertexBuffer(ent, ent->model->vb[surf], 0, surfverts);
 
 		pSurface = (md3Surface_t*)((byte*)pSurface + pSurface->ofsEnd);
+	}
+
+	if (r_pendingflip)
+	{
+		Mat4Scale(r_projection_matrix, -1, 1, 1);
+		R_ProgUniformMatrix4fv(LOC_PROJECTION, 1, r_projection_matrix);
 	}
 
 	if (r_speeds->value && anythingToDraw)

--- a/src/renderer_gl2/r_progs.c
+++ b/src/renderer_gl2/r_progs.c
@@ -61,6 +61,12 @@ static glprogloc_t progUniLocs[NUM_LOCS] =
 	{ LOC_DLIGHT_COLORS,	"dlight_colors",	F_VECTOR3 },
 	{ LOC_DLIGHT_POS_AND_RAD, "dlight_pos_and_rad",	F_VECTOR4 },
 	{ LOC_DLIGHT_DIR_AND_CUTOFF, "dlight_dir_and_cutoff",	F_VECTOR4 },
+
+	/* matricies */
+	//[ISB] the type is incorrect but this isn't used anywhere so fix later I guess.
+	{ LOC_PROJECTION, "projection",	F_VECTOR4 },
+	{ LOC_MODELVIEW,  "modelview",	F_VECTOR4 },
+	{ LOC_LOCALMODELVIEW, "localmodelview",	F_VECTOR4 },
 };
 
 /* vertex attributes */
@@ -298,6 +304,17 @@ void R_ProgUniform4fv(int uniform, int count, float *val)
 {
 	CheckProgUni(uniform);
 	glUniform4fv(pCurrentProgram->locs[uniform], count, (const GLfloat*)val);
+}
+
+/*
+=================
+R_ProgUniformMatrix4fv
+=================
+*/
+void R_ProgUniformMatrix4fv(int uniform, int count, float* val)
+{
+	CheckProgUni(uniform);
+	glUniformMatrix4fv(pCurrentProgram->locs[uniform], count, GL_FALSE, (const GLfloat*)val);
 }
 
 /*

--- a/src/renderer_gl2/r_surf.c
+++ b/src/renderer_gl2/r_surf.c
@@ -200,6 +200,7 @@ void R_World_DrawAlphaSurfaces()
 	// go back to the world matrix
 	//
     glLoadMatrixf (r_world_matrix);
+	memcpy(r_local_matrix, mat4_identity, sizeof(mat4_t));
 
 	if (r_fastworld->value)
 	{
@@ -528,7 +529,6 @@ void R_DrawBrushModel (rentity_t *e)
 		modelorg[2] = DotProduct (temp, up);
 	}
 
-    glPushMatrix ();
 	e->angles[0] = -e->angles[0];	// stupid quake bug
 	e->angles[2] = -e->angles[2];	// stupid quake bug
 	R_RotateForEntity (e);
@@ -545,7 +545,6 @@ void R_DrawBrushModel (rentity_t *e)
 		R_SelectTextureUnit(0);
 	}
 
-	glPopMatrix ();
 }
 
 
@@ -804,6 +803,8 @@ void R_DrawWorld()
 
 	// build texture chains
 	R_World_RecursiveNode(r_worldmodel->nodes);
+	//no local transform needed for world. 
+	memcpy(r_local_matrix, mat4_identity, sizeof(mat4_t));
 
 	if (r_fastworld->value)
 	{

--- a/src/renderer_gl2/r_world.c
+++ b/src/renderer_gl2/r_world.c
@@ -218,6 +218,8 @@ static void R_World_BeginRendering()
 	R_ProgUniform1f(LOC_WARPSTRENGTH, 0.f);
 	R_ProgUniform2f(LOC_FLOWSTRENGTH, 0.f, 0.f);
 
+	R_ProgUniformMatrix4fv(LOC_LOCALMODELVIEW, 1, r_local_matrix);
+
 	gfx_world.uniformflags = 0; //Always force a uniform update if needed
 	gfx_world.isRenderingWorld = true;
 }


### PR DESCRIPTION
… add dynamic lighting to models

Sprites are currently in a very broken state. I didn't implement a SSE-based matrix multiplier yet, though I wanted to. Lots of code still needs to be adjusted to use the new matrix uniforms, but the world and models are now using them. This adds a local modelview to entities which allows them to be positioned in the world correctly before lighting. 

Shader source attached
[shaders.zip](https://github.com/BraXi/pragma/files/14878778/shaders.zip)
