### PR TITLE
inline models don't take model slots

### DIFF
--- a/src/common/fileformats/bsp.h
+++ b/src/common/fileformats/bsp.h
@@ -198,7 +198,9 @@ typedef struct /* BSPX DECOUPLED LIGHTMAPS */
 #define	SURF_FLOWING	(1 << 6) /*64*/ 	// scroll towards S coord
 #define	SURF_NODRAW		(1 << 7) /*128*/ 	// don't bother referencing the texture
 #define	SURF_HINT		(1 << 8) /*256*/	// make a primary bsp splitter
-#define	SURF_SKIP		(1 << 9) /*256*/	// completely ignore, allowing non-closed brushes
+#define	SURF_SKIP		(1 << 9) /*512*/	// completely ignore, allowing non-closed brushes
+
+#define	SURF_DECAL		(1 << 10) /*1024*/	// surface is decal
 
 // ericw_tools additional flags
 #define SURF_ALPHATEST	(1 << 25) // alpha test flag

--- a/src/common/renderer.h
+++ b/src/common/renderer.h
@@ -135,6 +135,14 @@ typedef struct
 	float		white;			// highest of rgb
 } lightstyle_t;
 
+
+typedef struct
+{
+	vec3_t origin, angles;
+	float alpha;
+	struct model_s* model;
+} decal_t;
+
 typedef struct rdCamParams_s
 {
 	float	origin[3];
@@ -181,6 +189,13 @@ typedef struct
 {
 	// if api_version is different, the dll cannot be used
 	int		api_version;
+
+	int		rentity_size;
+	int		dlight_size;
+	int		particle_size;
+	int		lightstyle_size;
+	int		decal_size;
+	int		refdef_size;
 
 	// called when the library is loaded
 	qboolean	(*Init) ( void *hinstance, void *wndproc );

--- a/src/common/shared.h
+++ b/src/common/shared.h
@@ -330,7 +330,7 @@ typedef struct cmodel_s
 
 typedef struct csurface_s
 {
-	char		name[32]; // braxi -- was 16 (id's mistake)
+	char		name[32]; // braxi -- 32 to match qbsp
 	int			flags;
 	int			value;
 } csurface_t;

--- a/src/common/shared.h
+++ b/src/common/shared.h
@@ -382,19 +382,12 @@ typedef struct
 {
 	pmtype_t	pm_type;
 
-#if PROTOCOL_FLOAT_COORDS == 1
 	vec3_t		origin;
 	vec3_t		velocity;
 
 	vec3_t		mins;
 	vec3_t		maxs;
-#else
-	short		origin[3];		// 12.3
-	short		velocity[3];	// 12.3
 
-	short		mins[3];	// 12.3
-	short		maxs[3];	// 12.3
-#endif
 
 	int			pm_flags; 		// ducked, jump_held, etc
 	byte		pm_time;		// each unit = 8 ms

--- a/src/engine/client/cgame/cg_builtins.c
+++ b/src/engine/client/cgame/cg_builtins.c
@@ -51,6 +51,8 @@ static int CG_ModelIndex(char* name/*, qboolean fromServer*/)
 	for (index = 1; index < MAX_MODELS && cl.configstrings[CS_MODELS + index][0]; index++)
 		if (!strcmp(cl.configstrings[CS_MODELS + index], name))
 			return index;
+
+	// Fixme: BMODELS-LOVE
 }
 
 /*

--- a/src/engine/client/cgame/cg_flash.c
+++ b/src/engine/client/cgame/cg_flash.c
@@ -204,7 +204,7 @@ void CG_AddFlashLightToEntity(clentity_t *cent, rentity_t* parentEnt)
 	if (cent->current.number == cl.playernum + 1)
 		return; // dont draw world effect for local player
 
-	if (cent->current.modelindex && parentEnt->model)
+	if (cent->current.modelindex != 0 && parentEnt->model)
 	{
 		tag = re.TagIndexForName(parentEnt->model, "tag_light");
 		if (tag == -1)

--- a/src/engine/client/cgame/cg_weapon.c
+++ b/src/engine/client/cgame/cg_weapon.c
@@ -36,7 +36,7 @@ void CG_AddViewWeapon(player_state_t* ps, player_state_t* ops)
 	if (gun_model && CL_CheatsAllowed())
 		viewmodel.model = gun_model; // development tool
 	else
-		viewmodel.model = cl.model_draw[ps->viewmodel[0]];
+		viewmodel.model = CL_DrawModel(ps->viewmodel[0]);
 
 	if (!viewmodel.model)
 		return;
@@ -89,7 +89,7 @@ void CG_AddViewWeapon(player_state_t* ps, player_state_t* ops)
 	// second viewmodel is arms so just copy all params to it
 	if (ps->viewmodel[1])
 	{
-		viewmodel.model = cl.model_draw[ps->viewmodel[1]];
+		viewmodel.model = CL_DrawModel(ps->viewmodel[1]);
 		V_AddEntity(&viewmodel);
 	}
 }

--- a/src/engine/client/cgame/cg_weapon.c
+++ b/src/engine/client/cgame/cg_weapon.c
@@ -36,7 +36,7 @@ void CG_AddViewWeapon(player_state_t* ps, player_state_t* ops)
 	if (gun_model && CL_CheatsAllowed())
 		viewmodel.model = gun_model; // development tool
 	else
-		viewmodel.model = CL_DrawModel(ps->viewmodel[0]);
+		viewmodel.model = CL_GetDrawModel(ps->viewmodel[0]);
 
 	if (!viewmodel.model)
 		return;
@@ -89,7 +89,7 @@ void CG_AddViewWeapon(player_state_t* ps, player_state_t* ops)
 	// second viewmodel is arms so just copy all params to it
 	if (ps->viewmodel[1])
 	{
-		viewmodel.model = CL_DrawModel(ps->viewmodel[1]);
+		viewmodel.model = CL_GetDrawModel(ps->viewmodel[1]);
 		V_AddEntity(&viewmodel);
 	}
 }

--- a/src/engine/client/cgame/cg_world.c
+++ b/src/engine/client/cgame/cg_world.c
@@ -26,7 +26,7 @@ static int CG_HullForEntity(entity_state_t* ent)
 	if (ent->packedSolid == PACKED_BSP)
 	{
 		// explicit hulls in the BSP model
-		model = CL_ClipModel(ent->modelindex);
+		model = CL_GetClipModel(ent->modelindex);
 		if (!model)
 		{
 			Com_Error(ERR_DROP, "CG_HullForEntity: non BSP model for entity %i\n", ent->number);
@@ -153,7 +153,7 @@ int	CG_PointContents(vec3_t point)
 		if (ent->packedSolid != PACKED_BSP) // special value for bmodel
 			continue;
 
-		cmodel = CL_ClipModel((int)ent->modelindex);
+		cmodel = CL_GetClipModel((int)ent->modelindex);
 		if (!cmodel)
 			continue;
 

--- a/src/engine/client/cgame/cg_world.c
+++ b/src/engine/client/cgame/cg_world.c
@@ -36,11 +36,7 @@ static int CG_HullForEntity(entity_state_t* ent)
 	}
 
 	// extract bbox size
-#if PROTOCOL_FLOAT_COORDS == 1
 	MSG_UnpackSolid32(ent->packedSolid, bmins, bmaxs);
-#else
-	MSG_UnpackSolid16(ent->packedSolid, bmins, bmaxs);
-#endif
 
 	// create a temp hull from bounding box sizes
 	return CM_HeadnodeForBox(bmins, bmaxs);

--- a/src/engine/client/cgame/cg_world.c
+++ b/src/engine/client/cgame/cg_world.c
@@ -26,7 +26,7 @@ static int CG_HullForEntity(entity_state_t* ent)
 	if (ent->packedSolid == PACKED_BSP)
 	{
 		// explicit hulls in the BSP model
-		model = cl.model_clip[ent->modelindex];
+		model = CL_ClipModel(ent->modelindex);
 		if (!model)
 		{
 			Com_Error(ERR_DROP, "CG_HullForEntity: non BSP model for entity %i\n", ent->number);
@@ -153,7 +153,7 @@ int	CG_PointContents(vec3_t point)
 		if (ent->packedSolid != PACKED_BSP) // special value for bmodel
 			continue;
 
-		cmodel = cl.model_clip[(int)ent->modelindex];
+		cmodel = CL_ClipModel((int)ent->modelindex);
 		if (!cmodel)
 			continue;
 

--- a/src/engine/client/cl_entities.c
+++ b/src/engine/client/cl_entities.c
@@ -388,18 +388,10 @@ void CL_CalcViewValues()
 	ops = &oldframe->playerstate;
 
 	// see if the player entity was teleported this frame
-#if PROTOCOL_FLOAT_COORDS == 1
 	if (fabs((double)(ops->pmove.origin[0] - ps->pmove.origin[0])) > 256.0
 		|| abs(ops->pmove.origin[1] - ps->pmove.origin[1]) > 256.0
 		|| abs(ops->pmove.origin[2] - ps->pmove.origin[2]) > 256.0)
 		ops = ps;		// don't interpolate
-#else
-	if (fabs(ops->pmove.origin[0] - ps->pmove.origin[0]) > 256 * 8
-		|| abs(ops->pmove.origin[1] - ps->pmove.origin[1]) > 256 * 8
-		|| abs(ops->pmove.origin[2] - ps->pmove.origin[2]) > 256 * 8)
-		ops = ps;		// don't interpolate
-#endif
-
 
 	ent = &cl_entities[cl.playernum+1];
 	lerp = cl.lerpfrac;
@@ -424,14 +416,10 @@ void CL_CalcViewValues()
 			cl.refdef.view.origin[2] -= cl.predicted_step * (float)(SV_FRAMETIME_MSEC - delta) * 0.01f;
 	}
 	else
-	{	// just use interpolated values
-#if PROTOCOL_FLOAT_COORDS == 1
+	{	
+		// just use interpolated values
 		for(i = 0; i < 3; i++)
 			cl.refdef.view.origin[i] = ops->pmove.origin[i] + ops->viewoffset[i] + lerp * (ps->pmove.origin[i] + ps->viewoffset[i] - (ops->pmove.origin[i] + ops->viewoffset[i]));
-#else
-		for(i = 0; i < 3; i++)
-			cl.refdef.vieworigin[i] = ops->pmove.origin[i] * 0.125 + ops->viewoffset[i] + lerp * (ps->pmove.origin[i] * 0.125 + ps->viewoffset[i] - (ops->pmove.origin[i] * 0.125 + ops->viewoffset[i]));
-#endif
 	}
 
 

--- a/src/engine/client/cl_entities.c
+++ b/src/engine/client/cl_entities.c
@@ -163,7 +163,7 @@ void PositionRotatedEntityOnTag(rentity_t* entity, rentity_t* parent, int parent
 	vec3_t			tempAxis[3];
 
 //	Com_Printf("old %i cur %i lerp %f\n", parent->oldframe, parent->frame, 1.0 - parent->animbacklerp);
-	re.LerpTag(&lerped, cl.model_draw[parentModel], parent->oldframe, parent->frame, 1.0 - parent->animbacklerp, tagIndex);
+	re.LerpTag(&lerped, CL_DrawModel(parentModel), parent->oldframe, parent->frame, 1.0 - parent->animbacklerp, tagIndex);
 
 	VectorCopy(parent->origin, entity->origin);
 	for (i = 0; i < 3; i++) 
@@ -208,7 +208,7 @@ static inline void CL_EntityAddAttachedModels(clentity_t* clent, entity_state_t*
 		AxisClear(attachEnt.axis);
 		PositionRotatedEntityOnTag(&attachEnt, &r, clent->current.modelindex, (attachInfo->parentTag - 1));
 
-		attachEnt.model = cl.model_draw[state->attachments[i].modelindex];
+		attachEnt.model = CL_DrawModel(state->attachments[i].modelindex);
 		VectorAngles(attachEnt.axis[0], attachEnt.axis[2], angles);
 		VectorCopy(angles, attachEnt.angles);
 
@@ -313,14 +313,14 @@ void CL_AddPacketEntities(frame_t* frame)
 
 
 		rent.skinnum = state->skinnum;
-		rent.model = cl.model_draw[state->modelindex];
+		rent.model = CL_DrawModel(state->modelindex);
 //		rent.renderfx = state->renderFlags; // set later on
 
 
 		//
 		// if entity has no model just skip at this point
 		//
-		if (!state->modelindex)
+		if (state->modelindex == 0)
 			continue;
 
 		//

--- a/src/engine/client/cl_entities.c
+++ b/src/engine/client/cl_entities.c
@@ -163,7 +163,7 @@ void PositionRotatedEntityOnTag(rentity_t* entity, rentity_t* parent, int parent
 	vec3_t			tempAxis[3];
 
 //	Com_Printf("old %i cur %i lerp %f\n", parent->oldframe, parent->frame, 1.0 - parent->animbacklerp);
-	re.LerpTag(&lerped, CL_DrawModel(parentModel), parent->oldframe, parent->frame, 1.0 - parent->animbacklerp, tagIndex);
+	re.LerpTag(&lerped, CL_GetDrawModel(parentModel), parent->oldframe, parent->frame, 1.0 - parent->animbacklerp, tagIndex);
 
 	VectorCopy(parent->origin, entity->origin);
 	for (i = 0; i < 3; i++) 
@@ -208,7 +208,7 @@ static inline void CL_EntityAddAttachedModels(clentity_t* clent, entity_state_t*
 		AxisClear(attachEnt.axis);
 		PositionRotatedEntityOnTag(&attachEnt, &r, clent->current.modelindex, (attachInfo->parentTag - 1));
 
-		attachEnt.model = CL_DrawModel(state->attachments[i].modelindex);
+		attachEnt.model = CL_GetDrawModel(state->attachments[i].modelindex);
 		VectorAngles(attachEnt.axis[0], attachEnt.axis[2], angles);
 		VectorCopy(angles, attachEnt.angles);
 
@@ -313,7 +313,7 @@ void CL_AddPacketEntities(frame_t* frame)
 
 
 		rent.skinnum = state->skinnum;
-		rent.model = CL_DrawModel(state->modelindex);
+		rent.model = CL_GetDrawModel(state->modelindex);
 //		rent.renderfx = state->renderFlags; // set later on
 
 

--- a/src/engine/client/cl_main.c
+++ b/src/engine/client/cl_main.c
@@ -222,7 +222,7 @@ void CL_Record_f (void)
 	for(i = 0; i < MAX_GENTITIES; i++)
 	{
 		ent = &cl_entities[i].baseline;
-		if (!ent->modelindex)
+		if (ent->modelindex == 0)
 			continue;
 
 		if (buf.cursize + 64 > buf.maxsize)
@@ -1046,13 +1046,20 @@ void CL_PrintEnts_f(void)
 		printvec("old_origin", ent->old_origin);
 		printvec("angles", ent->angles);
 
-		if (ent->modelindex)
+		if (ent->modelindex > 0)
+			Com_Printf("modelindex: %i (%s)\n", ent->modelindex, cl.configstrings[CS_MODELS + ent->modelindex]);
+		else
+			Com_Printf("modelindex: %i\n", ent->modelindex);
+
+#if 0 // FIXME: BMODELS-LOVE
+		if (ent->modelindex != 0)
 		{
 			if(cl.configstrings[CS_MODELS + ent->modelindex][0] == '*')
 				Com_Printf("brush: '%s' (modelindex %i)\n", cl.configstrings[CS_MODELS + ent->modelindex], ent->modelindex);
 			else
 				Com_Printf("model: '%s' (frame %i, skinnum %i, modelindex %i)\n", cl.configstrings[CS_MODELS + ent->modelindex], ent->frame, ent->skinnum, ent->modelindex);
 		}
+#endif
 	}
 
 	Com_Printf("\nnum frame entities: %i\n", cl.frame.num_entities);
@@ -1514,3 +1521,34 @@ void CL_Shutdown(void)
 }
 
 
+struct model_s *CL_DrawModel(int modelindex)
+{
+	if (modelindex >= 0)
+	{
+		return cl.model_draw[modelindex];
+	}
+	else if (modelindex < 0)
+	{
+		return cl.inlinemodel_draw[abs(modelindex)];
+	}
+	else
+	{
+		return NULL;
+	}
+}
+
+cmodel_t* CL_ClipModel(int modelindex)
+{
+	if (modelindex >= 0)
+	{
+		return cl.model_clip[modelindex];
+	}
+	else if (modelindex < 0)
+	{
+		return cl.inlinemodel_clip[abs(modelindex)];
+	}
+	else
+	{
+		return NULL;
+	}
+}

--- a/src/engine/client/cl_main.c
+++ b/src/engine/client/cl_main.c
@@ -1521,15 +1521,27 @@ void CL_Shutdown(void)
 }
 
 
-struct model_s *CL_DrawModel(int modelindex)
+/*
+===============
+CL_GetDrawModel
+Returns the pointer to drawable model.
+===============
+*/
+struct model_s *CL_GetDrawModel(int modelindex)
 {
+	int realindex;
 	if (modelindex >= 0)
 	{
 		return cl.model_draw[modelindex];
 	}
 	else if (modelindex < 0)
 	{
-		return cl.inlinemodel_draw[abs(modelindex)];
+		realindex = abs(modelindex);
+		if (realindex >= CM_NumInlineModels())
+		{
+			Com_Error(ERR_DROP, "%s bad inline model index (%i)\n", __FUNCTION__, modelindex);
+		}
+		return cl.inlinemodel_draw[realindex];
 	}
 	else
 	{
@@ -1537,15 +1549,28 @@ struct model_s *CL_DrawModel(int modelindex)
 	}
 }
 
-cmodel_t* CL_ClipModel(int modelindex)
+/*
+===============
+CL_GetClipModel
+Returns inline clip model for collision.
+===============
+*/
+cmodel_t* CL_GetClipModel(int modelindex)
 {
+	int realindex;
+
 	if (modelindex >= 0)
 	{
 		return cl.model_clip[modelindex];
 	}
 	else if (modelindex < 0)
 	{
-		return cl.inlinemodel_clip[abs(modelindex)];
+		realindex = abs(modelindex);
+		if (realindex >= CM_NumInlineModels())
+		{
+			Com_Error(ERR_DROP, "%s bad inline model index (%i)\n", __FUNCTION__, modelindex);
+		}
+		return cl.inlinemodel_clip[realindex];
 	}
 	else
 	{

--- a/src/engine/client/cl_parse.c
+++ b/src/engine/client/cl_parse.c
@@ -288,7 +288,8 @@ void CL_ParseStartSoundPacket(void)
 	}
 
 	if (flags & SND_POS)
-	{	// positioned in space
+	{	
+		// positioned in space
 		MSG_ReadPos (&net_message, pos_v);
  
 		pos = pos_v;
@@ -662,7 +663,7 @@ void CL_ParseDelta(entity_state_t* from, entity_state_t* to, int number, int bit
 	// looping sound
 	if (bits & U_LOOPSOUND)
 	{
-#ifdef PROTOCOL_EXTENDED_ASSETS
+#ifdef PROTO_SHORT_INDEXES
 		to->loopingSound = MSG_ReadShort(&net_message);
 #else
 		to->loopingSound = MSG_ReadByte(&net_message);

--- a/src/engine/client/cl_parse.c
+++ b/src/engine/client/cl_parse.c
@@ -565,42 +565,27 @@ void CL_ParseDelta(entity_state_t* from, entity_state_t* to, int number, int bit
 		to->eType = MSG_ReadByte(&net_message);
 	}
 
-	// main model
-	if (bits & U_MODELINDEX_8)
-		to->modelindex = MSG_ReadByte(&net_message);
+	// model and part bits
 	if (bits & U_MODELINDEX_16)
+	{
 		to->modelindex = MSG_ReadShort(&net_message);
-
-	// hidden parts
-	if (bits & U_MODELINDEX_8 || bits & U_MODELINDEX_16)
 		to->hidePartBits = MSG_ReadByte(&net_message);
+	}
 
 	// attached models
 	if (bits & U_ATTACHMENT_1)
 	{
-#ifdef PROTOCOL_EXTENDED_ASSETS
 		to->attachments[0].modelindex = MSG_ReadShort(&net_message);
-#else
-		to->attachments[0].modelindex = MSG_ReadByte(&net_message);
-#endif
 		to->attachments[0].parentTag = MSG_ReadByte(&net_message);
 	}
 	if (bits & U_ATTACHMENT_2)
 	{
-#ifdef PROTOCOL_EXTENDED_ASSETS
 		to->attachments[1].modelindex = MSG_ReadShort(&net_message);
-#else
-		to->attachments[1].modelindex = MSG_ReadByte(&net_message);
-#endif
 		to->attachments[1].parentTag = MSG_ReadByte(&net_message);
 	}
 	if (bits & U_ATTACHMENT_3)
 	{
-#ifdef PROTOCOL_EXTENDED_ASSETS
 		to->attachments[2].modelindex = MSG_ReadShort(&net_message);
-#else
-		to->attachments[2].modelindex = MSG_ReadByte(&net_message);
-#endif
 		to->attachments[2].parentTag = MSG_ReadByte(&net_message);
 	}
 
@@ -693,11 +678,7 @@ void CL_ParseDelta(entity_state_t* from, entity_state_t* to, int number, int bit
 	// solid
 	if (bits & U_PACKEDSOLID)
 	{
-#if PROTOCOL_FLOAT_COORDS == 1
 		to->packedSolid = MSG_ReadLong(&net_message);
-#else
-		to->packedSolid = MSG_ReadShort(&net_message);
-#endif
 	}
 }
 
@@ -921,24 +902,14 @@ void CL_ParsePlayerstate(frame_t* oldframe, frame_t* newframe)
 
 	if (flags & PS_M_ORIGIN)
 	{
-#if PROTOCOL_FLOAT_COORDS == 1
 		for (i = 0; i < 3; i++)
 			state->pmove.origin[i] = MSG_ReadFloat(&net_message);
-#else
-		for (i = 0; i < 3; i++)
-			state->pmove.origin[i] = MSG_ReadShort(&net_message);
-#endif
 	}
 
 	if (flags & PS_M_VELOCITY)
 	{
-#if PROTOCOL_FLOAT_COORDS == 1
 		for (i = 0; i < 3; i++)
 			state->pmove.velocity[i] = MSG_ReadFloat(&net_message);
-#else
-		for (i = 0; i < 3; i++)
-			state->pmove.velocity[i] = MSG_ReadShort(&net_message);
-#endif
 	}
 
 	if (flags & PS_M_TIME)
@@ -997,13 +968,8 @@ void CL_ParsePlayerstate(frame_t* oldframe, frame_t* newframe)
 
 	if (flags & PS_VIEWMODEL_INDEX)
 	{
-#ifdef PROTOCOL_EXTENDED_ASSETS
 		state->viewmodel[0] = MSG_ReadShort(&net_message);
 		state->viewmodel[1] = MSG_ReadShort(&net_message);
-#else
-		state->viewmodel[0] = MSG_ReadByte(&net_message);
-		state->viewmodel[1] = MSG_ReadByte(&net_message);
-#endif
 	}
 
 	if (flags & PS_VIEWMODEL_PARAMS)
@@ -1162,15 +1128,9 @@ void CL_ParseFrame(void)
 			cls.state = CS_ACTIVE;
 			cl.force_refdef = true;
 
-#if PROTOCOL_FLOAT_COORDS == 1
 			cl.predicted_origin[0] = cl.frame.playerstate.pmove.origin[0];
 			cl.predicted_origin[1] = cl.frame.playerstate.pmove.origin[1];
 			cl.predicted_origin[2] = cl.frame.playerstate.pmove.origin[2];
-#else
-			cl.predicted_origin[0] = cl.frame.playerstate.pmove.origin[0] * 0.125;
-			cl.predicted_origin[1] = cl.frame.playerstate.pmove.origin[1] * 0.125;
-			cl.predicted_origin[2] = cl.frame.playerstate.pmove.origin[2] * 0.125;
-#endif
 
 			VectorCopy(cl.frame.playerstate.viewangles, cl.predicted_angles);
 

--- a/src/engine/client/cl_predict.c
+++ b/src/engine/client/cl_predict.c
@@ -47,13 +47,8 @@ void CL_CheckPredictionError (void)
 		VectorCopy (cl.frame.playerstate.pmove.origin, cl.predicted_origins[frame]);
 
 		// save for error itnerpolation
-#if PROTOCOL_FLOAT_COORDS == 1
 		for (i = 0; i < 3; i++)
 			cl.prediction_error[i] = delta[i];
-#else
-		for (i = 0; i < 3; i++)
-			cl.prediction_error[i] = delta[i] * 0.125;
-#endif
 	}
 }
 
@@ -98,12 +93,9 @@ void CL_ClipMoveToEntities ( vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end,
 			angles = ent->angles;
 		}
 		else
-		{	// encoded bbox
-#if PROTOCOL_FLOAT_COORDS == 1
+		{	
+			// encoded bbox
 			MSG_UnpackSolid32(ent->packedSolid, bmins, bmaxs);
-#else
-			MSG_UnpackSolid16(ent->packedSolid, bmins, bmaxs);
-#endif
 
 			headnode = CM_HeadnodeForBox (bmins, bmaxs);
 			angles = vec3_origin;	// boxes don't rotate
@@ -275,23 +267,14 @@ void CL_PredictMovement (void)
 	step = pm.s.origin[2] - oldz;
 	if (step > 63 && step < 160 && (pm.s.pm_flags & PMF_ON_GROUND) )
 	{
-#if PROTOCOL_FLOAT_COORDS == 1
 		cl.predicted_step = step;
-#else
-		cl.predicted_step = step * 0.125;
-#endif
 		
 		cl.predicted_step_time = cls.realtime - cls.frametime * 500;
 	}
 
 	// copy results out for rendering
-#if PROTOCOL_FLOAT_COORDS == 1
 	VectorCopy(pm.s.origin, cl.predicted_origin);
-#else
-	cl.predicted_origin[0] = pm.s.origin[0] * 0.125;
-	cl.predicted_origin[1] = pm.s.origin[1] * 0.125;
-	cl.predicted_origin[2] = pm.s.origin[2] * 0.125;
-#endif
+
 	//set view angles
 	VectorCopy (pm.viewangles, cl.predicted_angles);
 }

--- a/src/engine/client/cl_predict.c
+++ b/src/engine/client/cl_predict.c
@@ -91,7 +91,7 @@ void CL_ClipMoveToEntities ( vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end,
 		if (ent->packedSolid == PACKED_BSP)
 		{	
 			// special value for bmodel
-			cmodel = CL_ClipModel((int)ent->modelindex);
+			cmodel = CL_GetClipModel((int)ent->modelindex);
 			if (!cmodel)
 				continue;
 			headnode = cmodel->headnode;

--- a/src/engine/client/cl_predict.c
+++ b/src/engine/client/cl_predict.c
@@ -89,8 +89,9 @@ void CL_ClipMoveToEntities ( vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end,
 			continue;
 
 		if (ent->packedSolid == PACKED_BSP)
-		{	// special value for bmodel
-			cmodel = cl.model_clip[(int)ent->modelindex];
+		{	
+			// special value for bmodel
+			cmodel = CL_ClipModel((int)ent->modelindex);
 			if (!cmodel)
 				continue;
 			headnode = cmodel->headnode;

--- a/src/engine/client/cl_view.c
+++ b/src/engine/client/cl_view.c
@@ -327,7 +327,7 @@ void CL_SetSkyFromConfigstring(void)
 CL_LoadModelAtIndex
 =================
 */
-void CL_LoadModelAtIndex(const char* name, int index)
+static void CL_LoadModelAtIndex(const char* name, int index)
 {
 	cl.model_draw[index] = re.RegisterModel(name);
 
@@ -377,13 +377,22 @@ void CL_PrepRefresh (void)
 	CG_RegisterMedia ();
 
 
+	SCR_UpdateScreen();
+
 	// load models referenced by server
 	for (i = 1; i < MAX_MODELS && cl.configstrings[CS_MODELS+i][0]; i++)
 	{
-		SCR_UpdateScreen ();
+		//SCR_UpdateScreen ();
 		Sys_SendKeyEvents ();	// pump message loop
 		CL_LoadModelAtIndex(cl.configstrings[CS_MODELS + i], i);
+
+		if (i % 4 == 0)
+		{
+			SCR_UpdateScreen(); // less waiting for vsync, faster load times, win.
+		}
 	}
+
+	SCR_UpdateScreen();
 
 	// load inline models
 	for (i = 1; i < CM_NumInlineModels(); i++)
@@ -391,6 +400,8 @@ void CL_PrepRefresh (void)
 		cl.inlinemodel_draw[i] = re.RegisterModel(va("*%i", i));
 		cl.inlinemodel_clip[i] = CM_InlineModel(va("*%i", i));
 	}
+
+	SCR_UpdateScreen();
 
 	Com_Printf ("images\r", i); 
 	SCR_UpdateScreen ();

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -101,11 +101,7 @@ typedef struct
 	usercmd_t	cmds[CMD_BACKUP];	// each mesage will send several old cmds
 	int			cmd_time[CMD_BACKUP];	// time sent, for calculating pings
 
-#ifdef PROTOCOL_FLOAT_COORDS
 	float		predicted_origins[CMD_BACKUP][3];	// for debug comparing against server
-#else
-	short		predicted_origins[CMD_BACKUP][3];	// for debug comparing against server
-#endif
 
 	float		predicted_step;				// for stair up smoothing
 	unsigned	predicted_step_time;
@@ -158,16 +154,15 @@ typedef struct
 
 	char		configstrings[MAX_CONFIGSTRINGS][MAX_QPATH];
 
+	// inline models are derived from BSP
+	struct model_s* inlinemodel_draw[MAX_MODELS];
+	struct cmodel_s* inlinemodel_clip[MAX_MODELS];
+
 	//
-	// locally derived information from server state
-	// indexes must match server indexes
+	// locally derived information from server state indexes must match server indexes
 	//
 	struct model_s		*model_draw[MAX_MODELS];
 	struct cmodel_s		*model_clip[MAX_MODELS];
-
-	
-	struct model_s		*inlinemodel_draw[MAX_MODELS];
-	struct cmodel_s		*inlinemodel_clip[MAX_MODELS];
 
 	struct sfx_s		*sound_precache[MAX_SOUNDS];
 	struct image_s		*image_precache[MAX_IMAGES];

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -165,6 +165,10 @@ typedef struct
 	struct model_s		*model_draw[MAX_MODELS];
 	struct cmodel_s		*model_clip[MAX_MODELS];
 
+	
+	struct model_s		*inlinemodel_draw[MAX_MODELS];
+	struct cmodel_s		*inlinemodel_clip[MAX_MODELS];
+
 	struct sfx_s		*sound_precache[MAX_SOUNDS];
 	struct image_s		*image_precache[MAX_IMAGES];
 } client_state_t;

--- a/src/engine/client/fx/fx_play.c
+++ b/src/engine/client/fx/fx_play.c
@@ -251,7 +251,7 @@ void FX_StartFXAttachedToEntity(int effectIndex, int entityIndex, char *tagName)
 		return;
 
 	cent = &cl_entities[entityIndex];
-	if (cent->current.modelindex <= 0)
+	if (cent->current.modelindex == 0)
 	{
 		Com_Printf("WARNING: entity  %i has no model (%s)\n", entityIndex, __FUNCTION__);
 		return;

--- a/src/engine/client/vid_dll.c
+++ b/src/engine/client/vid_dll.c
@@ -585,14 +585,28 @@ qboolean VID_LoadRefresh( char *name )
 	ri.GetBSPElementSize = _GetBSPElementSize;
 
 	GetRefAPI = (GetRefAPI_t)GetProcAddress(reflib_library, "GetRefAPI");
-	if ( (GetRefAPI) == 0 )
-		Com_Error( ERR_FATAL, "GetProcAddress failed on %s", name );
+	if ((GetRefAPI) == 0)
+	{
+		Com_Error(ERR_FATAL, "GetProcAddress failed on %s", name);
+		return false; //msvc
+	}
 
 	re = GetRefAPI(ri);
 	if (re.api_version != API_VERSION)
 	{
 		VID_FreeReflib ();
-		Com_Error (ERR_FATAL, "%s has incompatible api_version", name);
+		Com_Error (ERR_FATAL, "%s has incompatible api version.", name);
+	}
+
+	if (re.rentity_size != sizeof(rentity_t) ||
+		re.dlight_size != sizeof(dlight_t) ||
+		re.particle_size != sizeof(particle_t) ||
+		re.lightstyle_size != sizeof(lightstyle_t) ||
+		re.decal_size != sizeof(decal_t) ||
+		re.refdef_size != sizeof(refdef_t) )
+	{
+		VID_FreeReflib();
+		Com_Error(ERR_FATAL, "%s has incompatible data types.", name);
 	}
 
 	if ( re.Init( global_hInstance, MainWndProc ) == -1 )

--- a/src/engine/cmodel.c
+++ b/src/engine/cmodel.c
@@ -1098,7 +1098,7 @@ CM_TransformedPointContents
 Handles offseting and rotation of the end points for moving and rotating entities
 ==================
 */
-int	CM_TransformedPointContents(vec3_t p, int headnode, vec3_t origin, vec3_t angles)
+int CM_TransformedPointContents(vec3_t p, int headnode, vec3_t origin, vec3_t angles)
 {
 	vec3_t		p_l;
 	vec3_t		temp;
@@ -1108,9 +1108,9 @@ int	CM_TransformedPointContents(vec3_t p, int headnode, vec3_t origin, vec3_t an
 	// subtract origin offset
 	VectorSubtract (p, origin, p_l);
 
-	// rotate start and end into the models frame of reference
-	if (headnode != box_headnode && 
-	(angles[0] || angles[1] || angles[2]) )
+	// rotate start and end into the models frame of reference unless its entity
+	//if (headnode != box_headnode && (angles[0] || angles[1] || angles[2]))
+	if (headnode != box_headnode && !VectorCompare(angles, vec3_origin))
 	{
 		AngleVectors (angles, forward, right, up);
 

--- a/src/engine/cmodel.c
+++ b/src/engine/cmodel.c
@@ -727,22 +727,30 @@ cmodel_t *CM_LoadMap(char *name, qboolean clientload, unsigned *checksum)
 
 /*
 ==================
-CM_InlineModel
+CM_InlineModelNum
+Returns the inline model by number
+==================
+*/
+cmodel_t* CM_InlineModelNum(int index)
+{
+	if (index < 1 || index >= map_numInlineModels)
+		Com_Error(ERR_DROP, "CM_InlineModel: bad number %i", index);
 
+	return &map_inlineModels[index];
+}
+
+/*
+==================
+CM_InlineModel
 Returns the inline model by name
 ==================
 */
 cmodel_t* CM_InlineModel(const char* name)
 {
-	int		num;
-
 	if (!name || name[0] != '*')
 		Com_Error(ERR_DROP, "CM_InlineModel: bad name");
-	num = atoi(name + 1);
-	if (num < 1 || num >= map_numInlineModels)
-		Com_Error(ERR_DROP, "CM_InlineModel: bad number %i, (numcmodels=%i)", num, map_numInlineModels);
 
-	return &map_inlineModels[num];
+	return CM_InlineModelNum(atoi(name + 1));
 }
 
 /*

--- a/src/engine/cmodel.h
+++ b/src/engine/cmodel.h
@@ -22,6 +22,7 @@ COLLISION MODEL
 
 void		CM_FreeMap();
 cmodel_t* CM_LoadMap(char* name, qboolean clientload, unsigned* checksum);
+cmodel_t* CM_InlineModelNum(int index);
 cmodel_t* CM_InlineModel(const char* name); // *1, *2, etc
 
 int			CM_NumClusters();

--- a/src/engine/message.c
+++ b/src/engine/message.c
@@ -95,24 +95,14 @@ void MSG_WriteString(sizebuf_t* sb, const char* s)
 
 void MSG_WriteCoord(sizebuf_t* sb, float f)
 {
-#if PROTOCOL_FLOAT_COORDS == 1
 	MSG_WriteFloat(sb, f);
-#else
-	MSG_WriteShort(sb, (int)(f * 8));
-#endif
 }
 
 void MSG_WritePos(sizebuf_t* sb, vec3_t pos)
 {
-#if PROTOCOL_FLOAT_COORDS == 1
 	MSG_WriteFloat(sb, pos[0]);
 	MSG_WriteFloat(sb, pos[1]);
 	MSG_WriteFloat(sb, pos[2]);
-#else
-	MSG_WriteShort(sb, (int)(pos[0] * 8));
-	MSG_WriteShort(sb, (int)(pos[1] * 8));
-	MSG_WriteShort(sb, (int)(pos[2] * 8));
-#endif
 }
 
 void MSG_WriteAngle(sizebuf_t* sb, float f)
@@ -298,24 +288,14 @@ char* MSG_ReadStringLine(sizebuf_t* msg_read)
 
 float MSG_ReadCoord(sizebuf_t* msg_read)
 {
-#if PROTOCOL_FLOAT_COORDS == 1
 	return MSG_ReadFloat(msg_read);
-#else
-	return MSG_ReadShort(msg_read) * (1.0 / 8);
-#endif
 }
 
 void MSG_ReadPos(sizebuf_t* msg_read, vec3_t pos)
 {
-#if PROTOCOL_FLOAT_COORDS == 1
 	pos[0] = MSG_ReadFloat(msg_read);
 	pos[1] = MSG_ReadFloat(msg_read);
 	pos[2] = MSG_ReadFloat(msg_read);
-#else
-	pos[0] = MSG_ReadShort(msg_read) * (1.0 / 8);
-	pos[1] = MSG_ReadShort(msg_read) * (1.0 / 8);
-	pos[2] = MSG_ReadShort(msg_read) * (1.0 / 8);
-#endif
 }
 
 float MSG_ReadAngle(sizebuf_t* msg_read)

--- a/src/engine/message.c
+++ b/src/engine/message.c
@@ -337,9 +337,6 @@ void MSG_ReadData(sizebuf_t* msg_read, void* data, int len)
 }
 
 
-
-
-#if PROTOCOL_FLOAT_COORDS == 1
 int MSG_PackSolid32(const vec3_t mins, const vec3_t maxs)
 {
 	// Q2PRO code
@@ -367,18 +364,3 @@ void MSG_UnpackSolid32(int packedsolid, vec3_t mins, vec3_t maxs)
 	VectorSet(mins, -x, -y, -zd);
 	VectorSet(maxs, x, y, zu);
 }
-#else
-void MSG_UnpackSolid16(int packedsolid, vec3_t bmins, vec3_t bmaxs)
-{
-	int		x, zd, zu;
-	// encoded bbox
-	x = 8 * ((int)packedsolid & 31);
-	zd = 8 * (((int)packedsolid >> 5) & 31);
-	zu = 8 * (((int)packedsolid >> 10) & 63) - 32;
-
-	bmins[0] = bmins[1] = -x;
-	bmaxs[0] = bmaxs[1] = x;
-	bmins[2] = -zd;
-	bmaxs[2] = zu;
-}
-#endif

--- a/src/engine/message.h
+++ b/src/engine/message.h
@@ -55,12 +55,8 @@ float	MSG_ReadAngle16(sizebuf_t* sb);
 void	MSG_ReadDir(sizebuf_t* sb, vec3_t vector);
 void	MSG_ReadData(sizebuf_t* sb, void* buffer, int size);
 
+int		MSG_PackSolid32(const vec3_t mins, const vec3_t maxs);
+void	MSG_UnpackSolid32(int packedsolid, vec3_t mins, vec3_t maxs);
 
-#if PROTOCOL_FLOAT_COORDS == 1
-	int MSG_PackSolid32(const vec3_t mins, const vec3_t maxs);
-	void MSG_UnpackSolid32(int packedsolid, vec3_t mins, vec3_t maxs);
-#else
-	void MSG_UnpackSolid16(int packedsolid, vec3_t bmins, vec3_t bmaxs);
-#endif
 
 #endif /*_PRAGMA_MESSAGE_H_*/

--- a/src/engine/pragma.c
+++ b/src/engine/pragma.c
@@ -577,7 +577,7 @@ void MSG_WriteDeltaEntity(entity_state_t* from, entity_state_t* to, sizebuf_t* m
 	// looping sound
 	if (bits & U_LOOPSOUND)
 	{
-#if PROTOCOL_EXTENDED_ASSETS
+#if PROTO_SHORT_INDEXES
 		MSG_WriteShort(msg, to->loopingSound);
 #else
 		MSG_WriteByte(msg, to->loopingSound);

--- a/src/engine/pragma.c
+++ b/src/engine/pragma.c
@@ -380,10 +380,7 @@ void MSG_WriteDeltaEntity(entity_state_t* from, entity_state_t* to, sizebuf_t* m
 	// main model
 	if (to->modelindex != from->modelindex || to->hidePartBits != from->hidePartBits)
 	{
-		if (to->modelindex > 255)
-			bits |= U_MODELINDEX_16; // short
-		else
-			bits |= U_MODELINDEX_8; // byte	
+		bits |= U_MODELINDEX_16; // short
 	}
 
 	// attached models
@@ -464,8 +461,6 @@ void MSG_WriteDeltaEntity(entity_state_t* from, entity_state_t* to, sizebuf_t* m
 		MSG_WriteByte(msg, to->eType);
 
 	// main model
-	if (bits & U_MODELINDEX_8)
-		MSG_WriteByte(msg, to->modelindex);
 	if (bits & U_MODELINDEX_16)
 		MSG_WriteShort(msg, to->modelindex);
 

--- a/src/engine/pragma.c
+++ b/src/engine/pragma.c
@@ -380,7 +380,7 @@ void MSG_WriteDeltaEntity(entity_state_t* from, entity_state_t* to, sizebuf_t* m
 	// main model
 	if (to->modelindex != from->modelindex || to->hidePartBits != from->hidePartBits)
 	{
-		bits |= U_MODELINDEX_16; // short
+		bits |= U_MODELINDEX_16;
 	}
 
 	// attached models
@@ -460,40 +460,27 @@ void MSG_WriteDeltaEntity(entity_state_t* from, entity_state_t* to, sizebuf_t* m
 	if (bits & U_ETYPE)
 		MSG_WriteByte(msg, to->eType);
 
-	// main model
+	// model and part bits
 	if (bits & U_MODELINDEX_16)
+	{
 		MSG_WriteShort(msg, to->modelindex);
-
-	// hidden parts
-	if(bits & U_MODELINDEX_8 || bits & U_MODELINDEX_16)
 		MSG_WriteByte(msg, to->hidePartBits);
+	}
 
 	// attached models
 	if (bits & U_ATTACHMENT_1)
 	{
-#ifdef PROTOCOL_EXTENDED_ASSETS
 		MSG_WriteShort(msg, to->attachments[0].modelindex);
-#else
-		MSG_WriteByte(msg, to->attachments[0].modelindex);
-#endif
 		MSG_WriteByte(msg, to->attachments[0].parentTag);
 	}
 	if (bits & U_ATTACHMENT_2)
 	{
-#ifdef PROTOCOL_EXTENDED_ASSETS
 		MSG_WriteShort(msg, to->attachments[1].modelindex);
-#else
-		MSG_WriteByte(msg, to->attachments[1].modelindex);
-#endif
 		MSG_WriteByte(msg, to->attachments[1].parentTag);
 	}
 	if (bits & U_ATTACHMENT_3)
 	{
-#ifdef PROTOCOL_EXTENDED_ASSETS
 		MSG_WriteShort(msg, to->attachments[2].modelindex);
-#else
-		MSG_WriteByte(msg, to->attachments[2].modelindex);
-#endif
 		MSG_WriteByte(msg, to->attachments[2].parentTag);
 	}
 
@@ -590,7 +577,7 @@ void MSG_WriteDeltaEntity(entity_state_t* from, entity_state_t* to, sizebuf_t* m
 	// looping sound
 	if (bits & U_LOOPSOUND)
 	{
-#ifdef PROTOCOL_EXTENDED_ASSETS
+#if PROTOCOL_EXTENDED_ASSETS
 		MSG_WriteShort(msg, to->loopingSound);
 #else
 		MSG_WriteByte(msg, to->loopingSound);
@@ -604,27 +591,12 @@ void MSG_WriteDeltaEntity(entity_state_t* from, entity_state_t* to, sizebuf_t* m
 	// solid
 	if (bits & U_PACKEDSOLID)
 	{
-#if PROTOCOL_FLOAT_COORDS == 1
 		MSG_WriteLong(msg, to->packedSolid);
-#else
-		MSG_WriteShort(msg, to->solid);
-#endif
 	}
 }
 
 
-//============================================================
-
-
-
-
-
-
 //===========================================================================
-
-
-
-//============================================================================
 
 
 /*

--- a/src/engine/pragma.h
+++ b/src/engine/pragma.h
@@ -298,8 +298,8 @@ void CL_Frame (int msec);
 void Con_Print (char *text);
 void SCR_BeginLoadingPlaque (void);
 
-struct model_s* CL_DrawModel(int modelindex);
-cmodel_t* CL_ClipModel(int modelindex);
+struct model_s* CL_GetDrawModel(int modelindex);
+cmodel_t* CL_GetClipModel(int modelindex);
 #endif
 
 void SV_Init (void);

--- a/src/engine/pragma.h
+++ b/src/engine/pragma.h
@@ -297,6 +297,9 @@ void CL_Shutdown (void);
 void CL_Frame (int msec);
 void Con_Print (char *text);
 void SCR_BeginLoadingPlaque (void);
+
+struct model_s* CL_DrawModel(int modelindex);
+cmodel_t* CL_ClipModel(int modelindex);
 #endif
 
 void SV_Init (void);

--- a/src/engine/pragma.h
+++ b/src/engine/pragma.h
@@ -303,6 +303,8 @@ void SV_Init (void);
 void SV_Shutdown (char *finalmsg, qboolean reconnect);
 void SV_Frame (int msec);
 
+void SV_Error(const char* error_str, ...);
+
 qboolean Com_IsServerActive();
 
 #ifndef DEDICATED_ONLY

--- a/src/engine/pragma_config.h
+++ b/src/engine/pragma_config.h
@@ -35,10 +35,6 @@ See the attached GNU General Public License v2 for more details.
 // Include new GUI system
 #define NEW_GUI 1
 
-// net protocol will use floats for coordinates instead of shorts, this applies to pmove too
-// this also fixes some of pmove issues like dragging players motion towards 0,0,0 and higher jumps
-// all entities can move beyond +/- 4096qu boundary, 
-#define PROTOCOL_FLOAT_COORDS 1
 
 // See protocol.h for MORE!
 

--- a/src/engine/pragma_config.h
+++ b/src/engine/pragma_config.h
@@ -12,7 +12,6 @@ See the attached GNU General Public License v2 for more details.
 // MAIN CONFIGURATION FILE FOR ENGINE
 //
 
-
 #pragma once
 
 #ifndef PRAGMA_CONFIG_INCLUDED 
@@ -44,22 +43,24 @@ See the attached GNU General Public License v2 for more details.
 // See protocol.h for MORE!
 
 // protocol can use shorts when modelindex or soundindex exceed byte
-#define PROTOCOL_EXTENDED_ASSETS 1
 
-#define	MAX_CLIENTS			12		// absolute limit of maxclients, technicaly it can go up to 256...
-#define	MAX_GENTITIES		2048	// must change protocol to increase more
-#define	MAX_LIGHTSTYLES		256		// number of light style slots
+#define	MAX_CLIENTS			12		// maximum number of client slots
+#define	MAX_GENTITIES		2048	// number of game entities
+#define	MAX_LIGHTSTYLES		256		// number of light styles
 
-#ifdef PROTOCOL_EXTENDED_ASSETS
-#	define	MAX_MODELS			1024	// these can be sent over the net as shorts
-#	define	MAX_SOUNDS			1024	// so theoretical limit is 32768 for each
-#else
-#	define	MAX_MODELS			256		// these are sent over the net as bytes
-#	define	MAX_SOUNDS			256		// so they cannot be higher than 255
-#endif
-#define	MAX_IMAGES			256
-#define	MAX_ITEMS			256
+#define	MAX_ITEMS			256 // general config strings
 #define MAX_GENERAL			(MAX_CLIENTS*2)	// general config strings
+
+
+#define	MAX_MODELS			512		// number of models (excluding inline models)
+#define	MAX_SOUNDS			512
+#define	MAX_IMAGES			256
+
+#if (MAX_SOUNDS > 256 || MAX_IMAGES > 256)
+#define PROTOCOL_EXTENDED_ASSETS 1
+#endif
+
+
 
 
 // experimental -- variable server fps
@@ -81,10 +82,12 @@ See the attached GNU General Public License v2 for more details.
 #endif
 
 // version string
-#define PRAGMA_VERSION "0.32" 
+#define PRAGMA_VERSION "0.34" 
 #define PRAGMA_TIMESTAMP (__DATE__ " " __TIME__)
 
 // version history:
+// 0.34 - 24.09.2024 -- inline models separated from external models
+// 0.33 - 22.09.2024 -- lots of fixes from over time
 // 0.32 - 08.09.2024 -- source tree cleanup
 // 0.31 - 03.09.2024 -- prtool and pragma's own model/anim formats
 // 0.30 - xx.xx.2024 -- skeletal models

--- a/src/engine/pragma_config.h
+++ b/src/engine/pragma_config.h
@@ -12,10 +12,10 @@ See the attached GNU General Public License v2 for more details.
 // MAIN CONFIGURATION FILE FOR ENGINE
 //
 
-#pragma once
-
 #ifndef PRAGMA_CONFIG_INCLUDED 
 #define PRAGMA_CONFIG_INCLUDED 1
+
+#pragma once
 
 // what renderer DLL to use by default
 #define DEFAULT_RENDERER "gl2"
@@ -48,12 +48,12 @@ See the attached GNU General Public License v2 for more details.
 #define MAX_GENERAL			(MAX_CLIENTS*2)	// general config strings
 
 
-#define	MAX_MODELS			512		// number of models (excluding inline models)
+#define	MAX_MODELS			512		// number of models (excluding inline models), always short
 #define	MAX_SOUNDS			512
 #define	MAX_IMAGES			256
 
-#if (MAX_SOUNDS > 256 || MAX_IMAGES > 256)
-#define PROTOCOL_EXTENDED_ASSETS 1
+#if (MAX_SOUNDS > 256)
+#define PROTO_SHORT_INDEXES 1
 #endif
 
 

--- a/src/engine/pragma_engine.vcxproj
+++ b/src/engine/pragma_engine.vcxproj
@@ -214,7 +214,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>..\..\build</OutDir>
+    <OutDir>..\..\build\</OutDir>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <TargetName>pragma</TargetName>
     <IntDir>$(SolutionDir)\_objs\$(Platform)\$(ProjectName)\$(Configuration)\</IntDir>

--- a/src/engine/protocol.h
+++ b/src/engine/protocol.h
@@ -25,13 +25,9 @@ the svc_strings[] array in cl_parse.c should mirror svc_ops_e enum
 #ifndef _PRAGMA_PROTOCOL_H_
 #define _PRAGMA_PROTOCOL_H_
 
-#define PROTOCOL_REVISION 4
+#define PROTOCOL_REVISION	5
+#define	PROTOCOL_VERSION	('B'+'X'+PROTOCOL_REVISION)
 
-#ifdef PROTOCOL_EXTENDED_ASSETS
-#	define	PROTOCOL_VERSION	('B'+'X'+PROTOCOL_REVISION)
-#else
-#	define	PROTOCOL_VERSION	('B'+'X'+PROTOCOL_REVISION+'X')
-#endif
 
 // copies of entity_state_t to keep buffered
 #define	UPDATE_BACKUP	16	
@@ -165,8 +161,8 @@ enum clc_ops_e
 // try to pack the common update flags into the first byte
 #define	U_ETYPE				(1<<0)		// entity type
 #define	U_ORIGIN_XY			(1<<1)		// current origin
-#define	U_ANGLE_Y			(1<<2)		// current angles
-#define	U_ANGLE_Z			(1<<3)		// current angles
+#define	U_ANGLE_X			(1<<2)		// current angles
+#define	U_ANGLE_Y			(1<<3)		// current angles
 #define	U_ANIMFRAME_8		(1<<4)		// anim frame is 0-255
 #define	U_EVENT_8			(1<<5)		// byte
 #define	U_REMOVE			(1<<6)		// REMOVE this entity, don't add it
@@ -175,10 +171,10 @@ enum clc_ops_e
 // second byte
 #define	U_NUMBER_16			(1<<8)		// NUMBER8 is implicit if not set
 #define	U_ORIGIN_Z			(1<<9)
-#define	U_ANGLE_X			(1<<10)
-#define	U_MODELINDEX_8		(1<<11)		// modelindex is 0-255
+#define	U_ANGLE_Z			(1<<10)
+#define	U_MODELINDEX_16		(1<<11)		// modelindex
 #define U_RENDERFLAGS_8		(1<<12)		// fullbright, etc
-#define U_MODELINDEX_16		(1<<13)		// when modelindex > 255
+#define U_FREE_FLAG			(1<<13)		
 #define	U_EFFECTS_8			(1<<14)		// effects - EF_ flags
 #define	U_MOREBITS_2		(1<<15)		// -- read one additional byte --
 
@@ -187,9 +183,9 @@ enum clc_ops_e
 #define	U_ANIMFRAME_16		(1<<17)		// animframe greater than 255
 #define	U_RENDERFLAGS_16	(1<<18)		// 8 + 16 = 32B
 #define	U_EFFECTS_16		(1<<19)		// effects - EF_ flags, 8 + 16 = 32
-#define	U_ATTACHMENT_1		(1<<20)		// 
-#define	U_ATTACHMENT_2		(1<<21)		// 
-#define	U_ATTACHMENT_3		(1<<22)		// 
+#define	U_ATTACHMENT_1		(1<<20)		// model attached to a tag
+#define	U_ATTACHMENT_2		(1<<21)		// model attached to a tag
+#define	U_ATTACHMENT_3		(1<<22)		// model attached to a tag
 #define	U_MOREBITS_3		(1<<23)		// -- read one additional byte --
 
 // fourth byte

--- a/src/engine/script/qcvm_exec.c
+++ b/src/engine/script/qcvm_exec.c
@@ -38,9 +38,14 @@ Used for better error printing
 */
 char* Scr_BuiltinFuncName()
 {
-	CheckScriptVM(__FUNCTION__);
+	//CheckScriptVM(__FUNCTION__);
+
+	if(active_qcvm == NULL)
+		return "*none*";
+
 	if (active_qcvm->currentBuiltinFunc)
 		return active_qcvm->currentBuiltinFunc->name;
+
 	return "*none*";
 }
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -10,6 +10,10 @@ See the attached GNU General Public License v2 for more details.
 
 // server.h
 
+#ifndef _PRAGMA_SERVER_H_
+#define _PRAGMA_SERVER_H_
+
+#pragma once
 
 //define	PARANOID			// speed sapping error checking
 
@@ -19,6 +23,7 @@ See the attached GNU General Public License v2 for more details.
 
 //=============================================================================
 
+#define MODELINDEX_BAD 0
 #define MODELINDEX_WORLD 1
 
 
@@ -96,7 +101,7 @@ typedef struct
 	char				mapname[MAX_QPATH];		// BSP map name, or cinematic name
 
 	svmodel_t			models[MAX_MODELS];		// md3, smdl
-	int					num_models;
+	int					numModels;
 	int					numBrushModels;
 
 	qboolean			qcvm_active;
@@ -277,6 +282,8 @@ int SV_ImageIndex(const char* name);
 void SV_FreeModels();
 svmodel_t* SV_ModelForNum(int index);
 int SV_ModelIndexForName(const char *name);
+qboolean SV_IsBrushModel(int modelindex);
+
 int SV_ModelSurfIndexForName(int modelindex, const char* surfaceName);
 int SV_TagIndexForName(int modelindex, const char* tagName);
 orientation_t* SV_GetTag(int modelindex, int frame, const char* tagName);
@@ -426,3 +433,4 @@ trace_t SV_Trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, gentity_t *
 
 // passedict is explicitly excluded from clipping checks (normally NULL)
 
+#endif /*_PRAGMA_SERVER_H_*/

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -95,8 +95,9 @@ typedef struct
 
 	char				mapname[MAX_QPATH];		// BSP map name, or cinematic name
 
-	svmodel_t			models[MAX_MODELS];		// md3, smdl, brushmodels
+	svmodel_t			models[MAX_MODELS];		// md3, smdl
 	int					num_models;
+	int					numBrushModels;
 
 	qboolean			qcvm_active;
 	sv_globalvars_t*	script_globals;			// qcvm globals
@@ -274,8 +275,8 @@ int SV_ModelIndex(const char* name);
 int SV_SoundIndex(const char* name);
 int SV_ImageIndex(const char* name);
 void SV_FreeModels();
-svmodel_t* SV_ModelForNum(unsigned int index);
-svmodel_t* SV_ModelForName(const char *name);
+svmodel_t* SV_ModelForNum(int index);
+int SV_ModelIndexForName(const char *name);
 int SV_ModelSurfIndexForName(int modelindex, const char* surfaceName);
 int SV_TagIndexForName(int modelindex, const char* tagName);
 orientation_t* SV_GetTag(int modelindex, int frame, const char* tagName);

--- a/src/engine/server/sv_builtins.c
+++ b/src/engine/server/sv_builtins.c
@@ -348,7 +348,6 @@ void PFSV_setmodel(void)
 {
 	gentity_t* ent;
 	const char* name;
-	int modelindex;
 
 	ent = Scr_GetParmEntity(0);
 	name = Scr_GetParmString(1);
@@ -356,40 +355,9 @@ void PFSV_setmodel(void)
 	BUILTIN_NOT_UNUSED(ent);
 	BUILTIN_NOT_WORLD(ent);
 
-	if (!name || !name[0])
-	{
-		Scr_RunError("%s for entity %i with empty model name\n", Scr_BuiltinFuncName(), NUM_FOR_EDICT(ent));
-		return;
-	}
-
-	if (name[0] == '*')
-	{
-		Scr_RunError("%s tried to set inline model for entity %i\n", Scr_BuiltinFuncName(), NUM_FOR_EDICT(ent));
-		return;
-	}
-
-	//modelindex = SV_ModelForName(name)->modelindex; 
-	modelindex = SV_ModelIndex(name);
-	if (modelindex == (int)ent->v.modelindex)
-		return;
-
-	// make all surfaces visible when model change
-	SV_ShowEntitySurface(ent, NULL); 
-	SV_DetachAllModels(ent);
-
-	ent->v.model = Scr_SetString(name);
-	ent->v.modelindex = modelindex;
-
-	if (ent->v.solid == SOLID_BSP)
-	{
-		// keep this as error
-		Scr_RunError("%s set external model on a SOLID_BSP entity %i.\n", Scr_BuiltinFuncName(), NUM_FOR_EDICT(ent));
-
-		//Com_Printf("%s set external model on a SOLID_BSP entity %i, solidity changed to SOLID_NOT.\n", Scr_BuiltinFuncName(), NUM_FOR_EDICT(ent));
-		//ent->v.solid = SOLID_NOT;
-		//SV_LinkEdict(ent);
-	}
+	SV_SetEntityModel(ent, name);
 }
+
 
 /*
 =================
@@ -404,7 +372,6 @@ void PFSV_setbrushmodel(void)
 {
 	gentity_t* ent;
 	const char* name;
-	svmodel_t* mod;
 
 	ent = Scr_GetParmEntity(0);
 	name = Scr_GetParmString(1);
@@ -412,36 +379,7 @@ void PFSV_setbrushmodel(void)
 	BUILTIN_NOT_UNUSED(ent);
 	BUILTIN_NOT_WORLD(ent);
 
-	if (!name || !name[0])
-	{
-		Scr_RunError("%s for entity %i with empty model name\n", Scr_BuiltinFuncName(), NUM_FOR_EDICT(ent));
-		return;
-	}
-
-	mod = SV_ModelForName(name);
-	if (name[0] != '*' || mod->type != MOD_BRUSH || mod->bmodel == NULL)
-	{
-		Scr_RunError("%s with external model for entity %i\n", Scr_BuiltinFuncName(), NUM_FOR_EDICT(ent));
-		return;
-	}
-
-	if (mod->modelindex == (int)ent->v.modelindex)
-		return;
-
-	SV_ShowEntitySurface(ent, NULL);
-	SV_DetachAllModels(ent); // inline models have no tags anyway
-
-	ent->v.model = Scr_SetString(name);
-	ent->v.modelindex = mod->modelindex;
-
-	// inline models should always have their YAW set properly
-	if(ent->v.angles[YAW] == 0.0f)
-		ent->v.angles[YAW] = 360.0f;
-
-	// update mins and maxs and relink
-	VectorCopy(mod->bmodel->mins, ent->v.mins);
-	VectorCopy(mod->bmodel->maxs, ent->v.maxs);
-	SV_LinkEdict(ent);
+	SV_SetEntityBrushModel(ent, name);
 }
 
 /*

--- a/src/engine/server/sv_ccmds.c
+++ b/src/engine/server/sv_ccmds.c
@@ -22,15 +22,14 @@ These commands can only be entered from stdin or by a remote operator datagram
 
 void SV_ModelList_f(void)
 {
-	svmodel_t	* mod;
-	int		i;
-	int nonbmodels = 0, usedsize = 0;
+	svmodel_t *mod;
+	int i, usedsize = 0;
 
-	static char *mods[] = { "BAD", "BSP", "ALIAS", "SMDL" };
+	static const char *mods[] = { "BAD", "BSP", "ALIAS", "SMDL" };
 
 	if (sv.state == ss_dead)
 	{
-		Com_Printf("server must be running for sv_modelindex");
+		Com_Printf("Server must be running for sv_modelindex.");
 		return;
 	}
 
@@ -43,36 +42,22 @@ void SV_ModelList_f(void)
 	for (int index = 1; index < start+MAX_MODELS && sv.configstrings[start + index][0]; index++)
 		Com_Printf("%i: %s\n", index, sv.configstrings[start + index]);
 #endif
-	Com_Printf("\nserver models:\n");
-	Com_Printf("==============\n");
 
-	for (i = MODELINDEX_WORLD, mod = &sv.models[MODELINDEX_WORLD]; i < sv.num_models; i++, mod++)
+	Com_Printf("\nModels referenced by server:\n");
+
+	for (i = MODELINDEX_WORLD, mod = &sv.models[MODELINDEX_WORLD]; i < sv.numModels; i++, mod++)
 	{
 		if (!mod->name[0])
 			continue;
 
-		if (mod->type != MOD_BRUSH && mod->type != MOD_BAD)
-		{
-			nonbmodels++;
-			if(mod->type == MOD_ALIAS)
-				Com_Printf("%i: %s '%s' (%i frames)\n", i, mods[mod->type], mod->name, mod->numFrames);
-			else
-				Com_Printf("%i: %s '%s' \n", i, mods[mod->type], mod->name);
+		Com_Printf("%4i: %s (%s)\n", i, mod->name, mods[mod->type]);
 
-			//Com_Printf("%i: %s '%s' [%i anims, %i frames, %i tags, %i skins]\n", i, mods[mod->type], mod->name, mod->def.numAnimations, mod->numFrames, mod->numTags, mod->def.numSkins);
-			usedsize += mod->extradatasize;
-		}
-		else
-			Com_Printf("%i: %s '%s'\n", i, mods[mod->type], mod->name);
+		usedsize += mod->extradatasize;
 	}
 
 
-
 	Com_Printf("\n");
-	Com_Printf("... %i brush models.\n... %i external models.\nUsing %iKB of memory for external models.\n", CM_NumInlineModels(), nonbmodels, usedsize/1024);
-
-	// minus the 'bad model'
-	Com_Printf("Server is using %i models (limit is %i).\n", sv.num_models-1, MAX_MODELS-1);
+	Com_Printf("Server references %i external models and %i inline models (Using %iKB of memory)\n", sv.numModels-1, CM_NumInlineModels(), usedsize/1024);
 }
 
 

--- a/src/engine/server/sv_game.h
+++ b/src/engine/server/sv_game.h
@@ -8,6 +8,11 @@ Copyright (C) 1997-2001 Id Software, Inc.
 See the attached GNU General Public License v2 for more details.
 */
 
+#ifndef _PRAGMA_SV_GAME_H_
+#define _PRAGMA_SV_GAME_H_
+
+#pragma once
+
 #define MAX_PERS_FIELDS		64
 
 // link_t is only used for entity area links now
@@ -129,20 +134,26 @@ extern void SV_SpawnEntities(const char* mapname, char* entities, const char* sp
 //
 // sv_gentity.c
 //
-extern void SV_AttachModel(gentity_t* self, const char* tagname, const char* model);
-extern void SV_DetachModel(gentity_t* self, const char* model);
-extern void SV_DetachAllModels(gentity_t* self);
-extern void SV_HideEntitySurface(gentity_t* self, const char* surfaceName);
-extern void SV_ShowEntitySurface(gentity_t* self, const char* surfaceName);
-extern qboolean SV_EntityCanBeDrawn(gentity_t* self);
+void SV_AttachModel(gentity_t* self, const char* tagname, const char* model);
+void SV_DetachModel(gentity_t* self, const char* model);
+void SV_DetachAllModels(gentity_t* self);
+void SV_HideEntitySurface(gentity_t* self, const char* surfaceName);
+void SV_ShowEntitySurface(gentity_t* self, const char* surfaceName);
+qboolean SV_EntityCanBeDrawn(gentity_t* self);
 
-extern void ClientUserinfoChanged(gentity_t* ent, char* userinfo);
+void SV_SetEntityModel(gentity_t* ent, const char* modelName);
+void SV_SetEntityBrushModel(gentity_t* ent, const char* modelName);
 
-extern void ClientCommand(gentity_t* ent);
-extern void SV_RunWorldFrame(void);
+void ClientUserinfoChanged(gentity_t* ent, char* userinfo);
+
+void ClientCommand(gentity_t* ent);
+void SV_RunWorldFrame(void);
 
 // savegames stubs
-extern void WriteGame(const char* filename, qboolean autosave);
-extern void ReadGame(const char* filename);
-extern void WriteLevel(const char* filename);
-extern void ReadLevel(const char* filename);
+void WriteGame(const char* filename, qboolean autosave);
+void ReadGame(const char* filename);
+void WriteLevel(const char* filename);
+void ReadLevel(const char* filename);
+
+
+#endif /*_PRAGMA_SV_GAME_H_*/

--- a/src/engine/server/sv_gentity.c
+++ b/src/engine/server/sv_gentity.c
@@ -462,13 +462,6 @@ void SV_AttachModel(gentity_t *self, const char* tagname, const char *model)
 		return;
 	}
 
-	// FIXME: BMODELS-LOVE
-	//if (svmod->numTags == 0)
-	//{
-	//	Com_DPrintf(DP_GAME, "WARNING: entity %s has model without tags\n", Scr_GetString(self->v.classname));
-	//	return;
-	//}
-
 	modindex = SV_ModelIndexForName(model);
 	if (modindex == 0)
 	{
@@ -476,7 +469,7 @@ void SV_AttachModel(gentity_t *self, const char* tagname, const char *model)
 		return;
 	}
 
-	if(modindex < 0) //if (svmod->type == MOD_BRUSH)
+	if(SV_IsBrushModel(modindex))
 	{
 		Com_Error(ERR_DROP, "Can not attach brushmodels!\n");
 		return;

--- a/src/engine/server/sv_gentity.c
+++ b/src/engine/server/sv_gentity.c
@@ -201,7 +201,7 @@ int SV_TouchEntities(gentity_t* ent, int areatype)
 		if (!hit->inuse)
 			continue;
 
-		if (areatype == AREA_TRIGGERS && (int)hit->v.modelindex > 0)
+		if (areatype == AREA_TRIGGERS && (int)hit->v.modelindex != 0)
 		{
 			clip = SV_Clip(hit, ent->v.origin, ent->v.mins, ent->v.maxs, ent->v.origin, ent->v.clipmask);
 			if (clip.fraction == 1.0f)
@@ -647,7 +647,7 @@ qboolean SV_EntityCanBeDrawn(gentity_t* self)
 	svmodel_t* svmod;
 	int i, hidden;
 
-	if ((int)self->v.modelindex <= 0)
+	if ((int)self->v.modelindex == 0)
 		return false; // no modelindex
 
 	svmod = SV_ModelForNum((int)self->v.modelindex);

--- a/src/engine/server/sv_init.c
+++ b/src/engine/server/sv_init.c
@@ -39,8 +39,10 @@ static void SV_CreateBaseline()
 		svent = EDICT_NUM(entnum);
 		if (!svent->inuse)
 			continue;
-		if (!svent->s.modelindex && !svent->s.loopingSound && !svent->s.effects)
+
+		if (svent->s.modelindex == 0 && !svent->s.loopingSound && !svent->s.effects)
 			continue;
+
 		svent->s.number = entnum;
 
 		//

--- a/src/engine/server/sv_init.c
+++ b/src/engine/server/sv_init.c
@@ -226,16 +226,19 @@ void SV_SpawnServer (char *mapname, char *spawnpoint, server_state_t serverstate
 	//
 	// initialize server models, sv.models[1] is BSP, other models follow, inline models are addressed with negative indexes and are not part of model list
 	//
-	sv.models[0].type = MOD_BAD;
-	strcpy(sv.models[0].name, "none");
+	strcpy(sv.models[MODELINDEX_BAD].name, "none");
+	sv.models[MODELINDEX_BAD].type = MOD_BAD;
+	sv.models[MODELINDEX_BAD].modelindex = 0;
 
 	sv.models[MODELINDEX_WORLD].type = MOD_BRUSH;
 	sv.models[MODELINDEX_WORLD].modelindex = 1;
-	sv.num_models = 2; // because modelindex 0 is no model
+
+	sv.numModels = 2; // because modelindex 0 is no model
 
 	if (serverstate != ss_game)
 	{
 		// no real map -- cinematic server
+		SV_SetConfigString(CS_MODELS + 1, "");
 		sv.models[MODELINDEX_WORLD].bmodel = CM_LoadMap ("", false, &checksum_map);	
 	}
 	else
@@ -251,12 +254,12 @@ void SV_SpawnServer (char *mapname, char *spawnpoint, server_state_t serverstate
 	{
 		SV_SetConfigString((CS_MODELS + 1 + i), va("*%i", i));
 
-		strcpy(sv.models[sv.num_models].name, sv.configstrings[CS_MODELS + 1 + i]);
-		sv.models[sv.num_models].type = MOD_BRUSH;
-		sv.models[sv.num_models].bmodel = CM_InlineModel(sv.configstrings[CS_MODELS + 1 + i]);
-		sv.models[sv.num_models].modelindex = sv.num_models;
+		strcpy(sv.models[sv.numModels].name, sv.configstrings[CS_MODELS + 1 + i]);
+		sv.models[sv.numModels].type = MOD_BRUSH;
+		sv.models[sv.numModels].bmodel = CM_InlineModel(sv.configstrings[CS_MODELS + 1 + i]);
+		sv.models[sv.numModels].modelindex = sv.numModels;
 
-		sv.num_models++;
+		sv.numModels++;
 	}
 #endif
 

--- a/src/engine/server/sv_load.c
+++ b/src/engine/server/sv_load.c
@@ -55,21 +55,26 @@ int SV_ImageIndex(const char* name)
 /*
 ================
 SV_ModelForNum
-
-Returns svmodel for index
+Returns server model for given index
+Brush models will default to the NOMODEL
 ================
 */
 svmodel_t* SV_ModelForNum(int index)
 {
 	svmodel_t* mod;
 
-	if (index > sv.num_models) 
+	if (SV_IsBrushModel(index))
+	{
+		return &sv.models[0];
+	}
+
+	if (index > sv.numModels || index < 0) 
 	{
 		Com_Error(ERR_DROP, "SV_ModelForNum: wrong index %i\n", index);
 		return NULL; 
 	}
-
 	mod = &sv.models[index];
+
 	return mod;
 }
 
@@ -98,7 +103,7 @@ int SV_ModelIndexForName(const char *name)
 	}
 
 	//model = &sv.models[0];
-	for (mod = sv.models, num = 0; num < sv.num_models; num++, mod++)
+	for (mod = sv.models, num = 0; num < sv.numModels; num++, mod++)
 	{
 		if (!mod->name[0] || mod->type == MOD_BAD)
 			continue;
@@ -107,6 +112,21 @@ int SV_ModelIndexForName(const char *name)
 	}
 
 	return 0;
+}
+
+/*
+================
+SV_IsBrushModel
+================
+*/
+qboolean SV_IsBrushModel(int modelindex)
+{
+	if (modelindex == MODELINDEX_WORLD)
+		return true; // world
+
+	if (modelindex < 0 && modelindex >= (0 - CM_NumInlineModels()))
+		return true; // bmodels are negative
+	return false;
 }
 
 /*
@@ -171,19 +191,8 @@ static int SV_FindOrCreateAssetIndex(const char* name, int start, int max, const
 			return 0;
 	}
 	
-	// update configstring
-
-	strncpy(sv.configstrings[start + index], name, sizeof(sv.configstrings[index]));
-
-	if (sv.state != ss_loading)
-	{	// send the update to everyone
-		SZ_Clear(&sv.multicast);
-		MSG_WriteChar(&sv.multicast, SVC_CONFIGSTRING);
-		MSG_WriteShort(&sv.multicast, start + index);
-		MSG_WriteString(&sv.multicast, name);
-		SV_Multicast(vec3_origin, MULTICAST_ALL_R);
-	}
-
+	// update configstring and send updates when needed
+	SV_SetConfigString(start + index, name);
 	return index;
 }
 
@@ -274,8 +283,8 @@ void SV_FreeModels()
 {
 	svmodel_t* mod;
 
-	if(sv.num_models)
-		Com_Printf("Freeing %i models (server)...\n", sv.num_models);
+	if(sv.numModels)
+		Com_Printf("Freeing %i models (server)...\n", sv.numModels);
 
 	for (int i = 0; i < MAX_MODELS; i++)
 	{
@@ -286,7 +295,7 @@ void SV_FreeModels()
 		}
 		memset(&sv.models[i], 0, sizeof(svmodel_t));
 	}
-	sv.num_models = 0;
+	sv.numModels = 0;
 }
 
 
@@ -309,7 +318,7 @@ static svmodel_t* SV_LoadModel(const char* name, qboolean crash)
 		return NULL;
 	}
 
-	if (sv.num_models == MAX_MODELS)
+	if (sv.numModels == MAX_MODELS)
 	{
 		Com_Error(ERR_DROP, "SV_LoadModel: hit limit of %d models", MAX_MODELS);
 		return NULL; // shut up compiler
@@ -332,8 +341,8 @@ static svmodel_t* SV_LoadModel(const char* name, qboolean crash)
 //		if (model->type == MOD_BAD || !model->name[0])
 //			break;	// free spot
 //	}
-	model = &sv.models[sv.num_models];
-	model->modelindex = sv.num_models;
+	model = &sv.models[sv.numModels];
+	model->modelindex = sv.numModels;
 	
 	//
 	// load the file
@@ -373,7 +382,7 @@ static svmodel_t* SV_LoadModel(const char* name, qboolean crash)
 
 
 	SV_LoadDefForModel(model);
-	sv.num_models++;
+	sv.numModels++;
 	return model;
 }
 

--- a/src/engine/server/sv_main.c
+++ b/src/engine/server/sv_main.c
@@ -1184,3 +1184,41 @@ void SV_Shutdown (char *finalmsg, qboolean reconnect)
 	memset (&svs, 0, sizeof(svs));
 }
 
+
+/*
+================
+SV_Error
+An unrecoverable server error happened.
+================
+*/
+void SV_Error(const char* error_str, ...)
+{
+	qboolean error_in_qcvm;
+	va_list argptr;
+	static char msg[2048]; //MAXPRINTMSG, why so big?
+	static qboolean recursive;
+
+
+	if (recursive)
+	{
+		Sys_Error("Recursive server error after: %s", msg);
+	}
+
+	recursive = true;
+
+	va_start(argptr, error_str);
+	vsnprintf(msg, sizeof(msg), error_str, argptr);
+	va_end(argptr);
+
+	error_in_qcvm = (Scr_BuiltinFuncName()[0] == '*'); // FIXME: not the best way
+
+	if (error_in_qcvm)
+	{
+		Scr_RunError(msg);
+	}
+	else
+	{
+		Com_Error(ERR_DROP, msg);
+	}
+
+}

--- a/src/engine/server/sv_physics.c
+++ b/src/engine/server/sv_physics.c
@@ -437,20 +437,6 @@ qboolean SV_Push(gentity_t* pusher, vec3_t move, vec3_t amove)
 	pushed_t* p;
 	vec3_t		org, org2, move2, forward, right, up;
 
-#if PROTOCOL_FLOAT_COORDS == 0
-	// clamp the move to 1/8 units, so the position will be accurate for client side prediction
-	for (i = 0; i < 3; i++)
-	{
-		float	temp;
-		temp = move[i] * 8.0;
-		if (temp > 0.0)
-			temp += 0.5;
-		else
-			temp -= 0.5;
-		move[i] = 0.125 * (int)temp;
-	}
-#endif
-
 	// find the bounding box
 	for (i = 0; i < 3; i++)
 	{

--- a/src/engine/server/sv_script.c
+++ b/src/engine/server/sv_script.c
@@ -386,19 +386,11 @@ void Scr_ClientEndServerFrame(gentity_t* ent)
 	// save copy of pmove results
 	ent->client->old_pmove = ent->client->ps.pmove;
 
-#if PROTOCOL_FLOAT_COORDS == 1
 	for (i = 0; i < 3; i++)
 	{
 		ent->client->ps.pmove.origin[i] = ent->v.origin[i];
 		ent->client->ps.pmove.velocity[i] = ent->v.velocity[i];
 	}
-#else
-	for (i = 0; i < 3; i++)
-	{
-		pm->origin[i] = ent->v.origin[i] * 8.0;
-		pm->velocity[i] = ent->v.velocity[i] * 8.0;
-	}
-#endif
 }
 
 

--- a/src/engine/server/sv_user.c
+++ b/src/engine/server/sv_user.c
@@ -207,7 +207,7 @@ void SV_Baselines_f (void)
 	while ( sv_client->netchan.message.cursize <  MAX_MSGLEN/2 && start < MAX_GENTITIES)
 	{
 		base = &sv.baselines[start];
-		if (base->modelindex || base->loopingSound || base->effects)
+		if (base->modelindex != 0 || base->loopingSound || base->effects)
 		{
 			MSG_WriteByte (&sv_client->netchan.message, SVC_SPAWNBASELINE);
 			MSG_WriteDeltaEntity (&nullstate, base, &sv_client->netchan.message, true, true);

--- a/src/engine/server/sv_world.c
+++ b/src/engine/server/sv_world.c
@@ -329,7 +329,6 @@ void SV_UnlinkEdict (gentity_t *ent)
 	ent->area.prev = ent->area.next = NULL;
 }
 
-#if PROTOCOL_FLOAT_COORDS == 1
 static int SV_PackSolid32(gentity_t* ent)
 {
 	// Q2PRO code
@@ -354,47 +353,6 @@ static int SV_PackSolid32(gentity_t* ent)
 
 	return packedsolid;
 }
-#else
-static int SV_PackSolid16(gentity_t* ent)
-{
-	int i, j, k;
-	int packedsolid;
-	// assume that x/y are equal and symetric
-	i = ent->v.maxs[0] / 8;
-	if (i < 1)
-		i = 1;
-	if (i > 31)
-		i = 31;
-
-	// z is not symetric
-	j = (-ent->v.mins[2]) / 8;
-	if (j < 1)
-		j = 1;
-	if (j > 31)
-		j = 31;
-
-	// and z maxs can be negative...
-	k = (ent->v.maxs[2] + 32) / 8;
-	if (k < 1)
-		k = 1;
-	if (k > 63)
-		k = 63;
-
-	packedsolid = (k << 10) | (j << 5) | i;
-
-	if (developer->value)
-	{
-		vec3_t mins, maxs;
-
-		MSG_UnpackSolid16(packedsolid, mins, maxs);
-
-		if (!VectorCompare(ent->v.mins, mins) || !VectorCompare(ent->v.maxs, maxs))
-			Com_Printf("%s: bad mins/maxs on entity %d\n", __FUNCTION__, NUM_FOR_EDICT(ent));
-	}
-
-	return packedsolid;
-}
-#endif
 
 /*
 ===============
@@ -435,11 +393,7 @@ void SV_LinkEdict (gentity_t *ent)
 		}
 		else
 		{
-#if PROTOCOL_FLOAT_COORDS == 1
 			ent->s.packedSolid = SV_PackSolid32(ent);
-#else
-			ent->s.packedSolid = SV_PackSolid16(ent);
-#endif
 		}
 		break;
 	case SOLID_BSP:

--- a/src/engine/server/sv_world.c
+++ b/src/engine/server/sv_world.c
@@ -725,22 +725,6 @@ typedef struct
 
 /*
 ================
-SV_IsBrushModel
-================
-*/
-static qboolean SV_IsBrushModel(int modelindex)
-{
-	if (modelindex == 1)
-		return true; // world
-
-	if (modelindex < 0 && modelindex >= (0 - CM_NumInlineModels()))
-		return true; // bmodels are negative
-	return false;
-}
-
-
-/*
-================
 SV_HullForEntity
 
 Returns a headnode that can be used for testing or clipping an object of mins/maxs size.

--- a/src/engine/server/sv_write.c
+++ b/src/engine/server/sv_write.c
@@ -636,7 +636,7 @@ void SV_BuildClientFrame (client_t *client)
 		//
 		// ignore ents without visible models unless they have an effect, looping sound or event
 		//
-		//if (!ent->s.modelindex && !ent->s.effects && !ent->s.loopingSound && !ent->s.event)	
+		//if (ent->s.modelindex == 0 && !ent->s.effects && !ent->s.loopingSound && !ent->s.event)	
 		if (!SV_EntityCanBeDrawn(ent) && !ent->s.effects && !ent->s.loopingSound && !ent->s.event)
 		{
 			SV_RestoreEntityStateAfterClient(ent);
@@ -704,7 +704,7 @@ void SV_BuildClientFrame (client_t *client)
 						}
 					}
 
-					if (!ent->s.modelindex)
+					if (ent->s.modelindex == 0)
 					{	// don't send sounds if they will be attenuated away
 						vec3_t	delta;
 						float	len;
@@ -777,7 +777,7 @@ void SV_RecordDemoMessage (void)
 		// ignore ents without visible models unless they have an effect
 		if (ent->inuse &&
 			ent->s.number && 
-			(ent->s.modelindex || ent->s.effects || ent->s.loopingSound || ent->s.event) && 
+			((int)ent->s.modelindex != 0 || ent->s.effects || ent->s.loopingSound || ent->s.event) && 
 			!((int)ent->v.svflags & SVF_NOCLIENT))
 			MSG_WriteDeltaEntity (&nostate, &ent->s, &buf, false, true);
 

--- a/src/engine/server/sv_write.c
+++ b/src/engine/server/sv_write.c
@@ -235,24 +235,14 @@ void SV_WritePlayerstateToClient (client_frame_t *from, client_frame_t *to, size
 
 	if (pflags & PS_M_ORIGIN)
 	{
-#if PROTOCOL_FLOAT_COORDS == 1
 		for (i = 0; i < 3; i++)
 			MSG_WriteFloat(msg, ps->pmove.origin[i]);
-#else
-		for (i = 0; i < 3; i++)
-			MSG_WriteShort(msg, ps->pmove.origin[i]);
-#endif
 	}
 
 	if (pflags & PS_M_VELOCITY)
 	{
-#if PROTOCOL_FLOAT_COORDS == 1
 		for (i = 0; i < 3; i++)
 			MSG_WriteFloat(msg, ps->pmove.velocity[i]);
-#else
-		for (i = 0; i < 3; i++)
-			MSG_WriteShort(msg, ps->pmove.velocity[i]);
-#endif
 	}
 
 	if (pflags & PS_M_TIME)
@@ -318,13 +308,8 @@ void SV_WritePlayerstateToClient (client_frame_t *from, client_frame_t *to, size
 
 	if (pflags & PS_VIEWMODEL_INDEX)
 	{
-#ifdef PROTOCOL_EXTENDED_ASSETS
 		MSG_WriteShort(msg, ps->viewmodel[0]);
 		MSG_WriteShort(msg, ps->viewmodel[1]);
-#else
-		MSG_WriteByte(msg, ps->viewmodel[0]);
-		MSG_WriteByte(msg, ps->viewmodel[1]);
-#endif
 	}
 
 	if (pflags & PS_VIEWMODEL_PARAMS)
@@ -549,13 +534,8 @@ void SV_BuildClientFrame (client_t *client)
 	frame->senttime = svs.realtime; // save time for ping calculation later on
 
 	// find the client's PVS
-#if PROTOCOL_FLOAT_COORDS == 1
 	for (i = 0; i < 3; i++)
 		org[i] = clent->client->ps.pmove.origin[i] + clent->client->ps.viewoffset[i];
-#else
-	for (i = 0; i < 3; i++)
-		org[i] = clent->client->ps.pmove.origin[i] * 0.125 + clent->client->ps.viewoffset[i];
-#endif
 
 	leafnum = CM_PointLeafnum (org);
 	clientarea = CM_LeafArea (leafnum);

--- a/src/renderer_dll/r_init.c
+++ b/src/renderer_dll/r_init.c
@@ -441,6 +441,13 @@ refexport_t GetRefAPI(refimport_t rimp)
 
 	re.api_version = API_VERSION;
 
+	re.rentity_size = sizeof(rentity_t);
+	re.dlight_size = sizeof(dlight_t);
+	re.particle_size = sizeof(particle_t);
+	re.lightstyle_size = sizeof(lightstyle_t);
+	re.decal_size = sizeof(decal_t);
+	re.refdef_size = sizeof(refdef_t);
+
 	re.Init = R_Init;
 	re.Shutdown = R_Shutdown;
 

--- a/src/renderer_dll/r_model.c
+++ b/src/renderer_dll/r_model.c
@@ -585,7 +585,6 @@ Mod_BSP_LoadLightMaps
 */
 static void Mod_BSP_LoadLightMaps(lump_t *l)
 {
-	int count = 0;
 	if (!l->filelen)
 	{
 		pLoadModel->lightdatasize = -1;
@@ -763,12 +762,20 @@ static void Mod_BSP_LoadTexinfo(lump_t *l)
 		else
 		    out->next = NULL;
 
+		//ri.Printf(PRINT_ALL, "%5i %s flags: %i\n", i, in->texture, out->flags);
+		if (out->flags & SURF_SKY || out->flags & SURF_NODRAW || out->flags & SURF_SKIP)
+		{
+			// don't load textures for NODRAW, SKIP and SKY (its read from worldspawn key)
+			out->image = r_texture_missing;
+			continue;
+		}
+
 		// load up texture
 		Com_sprintf(name, sizeof(name), "textures/%s.tga", in->texture);
 		out->image = R_FindTexture(name, it_texture, true);
 		if (!out->image)
 		{
-			ri.Printf(PRINT_ALL, "%s: couldn't load '%s'\n", __FUNCTION__, name);
+			ri.Printf(PRINT_ALL, "%s: Missing texture '%s'.\n", __FUNCTION__, name);
 			out->image = r_texture_missing;
 		}
 


### PR DESCRIPTION
The changes to inline models:
- inline models are not written to config strings, thus are not sent to client, the client knows all bmodels anyway since they're stored in BSP
- inline models no longer take `svmodel_s` slots, thus they're no longer counting towards `MAX_MODELS` limit 
- all inline models (except the BSP world model) are accessed via negative model indexes
- the net protocol does send models as `short`, allowing for 65k models in total, since modelindexes can be negative sending them as `char/byte` is a bit too limiting
- a bit more strict renderer api check that verifies shared struct sizes


